### PR TITLE
Construct moment local to timezone

### DIFF
--- a/moment-timezone.js
+++ b/moment-timezone.js
@@ -10,7 +10,8 @@
 
 	function onload(moment) {
 		var oldZoneName = moment.fn.zoneName,
-			oldZoneAbbr = moment.fn.zoneAbbr,
+            oldZoneAbbr = moment.fn.zoneAbbr,
+            oldLocal = moment.fn.local,
 
 			defaultRule,
 			rules = {},
@@ -455,6 +456,15 @@
 				return this._z.displayName;
 			}
 		};
+
+        moment.fn.local = function () {
+            var offset, hours;
+            if (this._z) {
+                offset = this.zone() - moment(this.toArray()).zone();
+                return this.add('minutes', offset);
+            }
+            return oldLocal.call(this);
+        };
 
 		moment.fn.zoneName = function () {
 			if (this._z) {

--- a/tests/local.js
+++ b/tests/local.js
@@ -1,0 +1,13 @@
+var moment = require("../index");
+
+exports["local"] = {
+
+    "moment.fn.local" : function (t) {
+        t.equal(moment.tz("2013-01-01T00:00:00", "America/New_York").local().format(), "2013-01-01T00:00:00-05:00", "2013-01-01T00:00:00 in America/New_York should be 2013-01-01T00:00:00-05:00");
+        t.equal(moment.tz("2013-01-01T00:00:00", "America/Los_Angeles").local().format(), "2013-01-01T00:00:00-08:00", "2013-01-01T00:00:00 in America/Los_Angeles should be 2013-01-01T00:00:00-08:00");
+        t.equal(moment.tz("2013-01-01T00:00:00", "Europe/Paris").local().format(), "2013-01-01T00:00:00+01:00", "2013-01-01T00:00:00 in Europe/Paris should be 2013-01-01T00:00:00+01:00");
+        t.equal(moment.tz("2013-01-01T00:00:00", "Asia/Seoul").local().format(), "2013-01-01T00:00:00+09:00", "2013-01-01T00:00:00 in Asia/Seoul should be 2013-01-01T00:00:00+09:00");
+
+        t.done();
+    }
+};


### PR DESCRIPTION
Attempts to address #11

Here I took the approach of overriding `moment.fn.local` to mutate the moment so that its representation is local to its timezone if present. So

``` javascript
moment.tz("2013-01-01T00:00:00", "America/New_York").local().format()
// => "2013-01-01T00:00:00-05:00"

moment.tz("2013-01-01T00:00:00", "America/Los_Angeles").local().format()
// => "2013-01-01T00:00:00-08:00"
```

Let me know if you think this is on the right track and if so whether I should consider additional tests cases.
