### PR TITLE
Alternative construct moment local to timezone

### DIFF
--- a/moment-timezone.js
+++ b/moment-timezone.js
@@ -475,7 +475,10 @@
 			for (i = 0; i < len; i++) {
 				args[i] = arguments[i];
 			}
-			return moment.apply(null, args).tz(arguments[len]);
+			var m = moment.apply(null, args);
+			var preTzOffset = m.zone();
+			m.tz(arguments[len]);
+			return m.add('minutes', m.zone() - preTzOffset);
 		};
 
 		moment.tz.add = add;

--- a/tests/parse.js
+++ b/tests/parse.js
@@ -1,0 +1,13 @@
+var moment = require("../index");
+
+exports["parse"] = {
+  "parse" : function (t) {
+    t.equal(moment.tz("2013-01-01T00:00:00", "America/New_York").format(), "2013-01-01T00:00:00-05:00", "2013-01-01T00:00:00 in America/New_York should be 2013-01-01T00:00:00-05:00");
+    t.equal(moment.tz("2013-01-01T00:00:00", "America/Los_Angeles").format(), "2013-01-01T00:00:00-08:00", "2013-01-01T00:00:00 in America/Los_Angeles should be 2013-01-01T00:00:00-08:00");
+    t.equal(moment.tz("2013-01-01T00:00:00", "Europe/Paris").format(), "2013-01-01T00:00:00+01:00", "2013-01-01T00:00:00 in Europe/Paris should be 2013-01-01T00:00:00+01:00");
+    t.equal(moment.tz("2013-01-01T00:00:00", "Asia/Seoul").format(), "2013-01-01T00:00:00+09:00", "2013-01-01T00:00:00 in Asia/Seoul should be 2013-01-01T00:00:00+09:00");
+
+    t.equal(moment.tz([2013, 0, 1, 0, 0, 0], "America/New_York").format(), "2013-01-01T00:00:00-05:00", "Array constructor respects argument tzid");
+    t.done();
+  }
+};


### PR DESCRIPTION
An alternative to #18 to address #11 based on discussion in #18.  

```
moment.tz([2013, 0, 1, 0, 0, 0], "America/New_York").format() == "2013-01-01T00:00:00-05:00"
```
