### PR TITLE
if moment-timezone has already been loaded then don't do anything

### DIFF
--- a/moment-timezone.js
+++ b/moment-timezone.js
@@ -9,6 +9,10 @@
 	var VERSION = "0.0.1";
 
 	function onload(moment) {
+		if (moment.tz) {
+			return
+		}
+		
 		var oldZoneName = moment.fn.zoneName,
 			oldZoneAbbr = moment.fn.zoneAbbr,
 


### PR DESCRIPTION
It's possible to have multiple copies of `moment-timezone` in your NPM tree and thus have different copies of `moment-timezone` clobber each other.

This means that `moment.tz.add()` doesn't do what you want as it only adds the things to the current `tz` property of `moment` and not the latest copy of `tz`.
