### PR TITLE
allow newer versions of moment

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
 		}
 	],
 	"dependencies" : {
-		"moment" : "2.1.0"
+		"moment" : ">= 2.1.0"
 	},
 	"devDependencies" : {
 		"grunt"                  : "0.4.1",


### PR DESCRIPTION
We shouldn't be locking this to an old version of moment. This is also specifically important because of an upstream bug; see #34 and #17.
