### PR TITLE
Drastically improve perf with memoize

### DIFF
--- a/moment-timezone.js
+++ b/moment-timezone.js
@@ -53,6 +53,9 @@
 			this.timeRule  = +timeRule;
 			this.offset    = parseMinutes(offset);
 			this.letters   = letters || '';
+			this.date = memoize(this.date);
+			this.weekdayAfter = memoize(this.weekdayAfter);
+			this.lastWeekday = memoize(this.lastWeekday);
 		}
 
 		Rule.prototype = {
@@ -135,6 +138,7 @@
 		function RuleSet (name) {
 			this.name = name;
 			this.rules = [];
+			this.lastYearRule = memoize(this.lastYearRule);
 		}
 
 		RuleSet.prototype = {
@@ -252,6 +256,7 @@
 			this.offset = parseMinutes(offset);
 			this.ruleSet = ruleSet;
 			this.letters = letters;
+			this.lastRule = memoize(this.lastRule);
 
 			for (i = 0; i < untilArray.length; i++) {
 				untilArray[i] = +untilArray[i];
@@ -265,10 +270,7 @@
 			},
 
 			lastRule : function () {
-				if (!this._lastRule) {
-					this._lastRule = this.rule(this.until);
-				}
-				return this._lastRule;
+				return this.rule(this.until);
 			},
 
 			format : function (rule) {
@@ -288,6 +290,9 @@
 			this.name = normalizeName(name);
 			this.displayName = name;
 			this.zones = [];
+			this.zoneAndRule = memoize(this.zoneAndRule, function (mom) {
+				return +mom;
+			});
 		}
 
 		ZoneSet.prototype = {
@@ -327,6 +332,16 @@
 		/************************************
 			Global Methods
 		************************************/
+
+		function memoize (fn, keyFn) {
+			var cache = {};
+			return function (first) {
+				var key = keyFn ? keyFn.apply(this, arguments) : first;
+				return key in cache ?
+					cache[key] :
+					(cache[key] = fn.apply(this, arguments));
+			};
+		}
 
 		function addRules (rules) {
 			var i, j, rule;


### PR DESCRIPTION
I was using moment by itself for a project and then added moment-timezone and noticed a huge performance degradation. After some profiling and digging I noticed that many of the moment-timezone functions could and should be memoized. After applying this patch to my own project, performance returned to how it was pre-moment-timezone. The test speed is also very telling...

**before**

``` bash
>> 103487 assertions passed (63010ms)

Done, without errors.
```

**after**

``` bash
>> 103487 assertions passed (18811ms)

Done, without errors.
```

Furthermore, this speed difference is even more apparent in real world use cases were most computing is done in a single, relevant timezone.

Thanks for all the work put into this, timezones are a nightmare...
