### PR TITLE
Browserify Support

### DIFF
--- a/moment-timezone.js
+++ b/moment-timezone.js
@@ -505,9 +505,9 @@
 
 	if (typeof define === "function" && define.amd) {
 		define("moment-timezone", ["moment"], onload);
-	} else if (typeof window !== "undefined" && window.moment) {
-		onload(window.moment);
 	} else if (typeof module !== 'undefined') {
 		module.exports = onload(require('moment'));
+	} else if (typeof window !== "undefined" && window.moment) {
+		onload(window.moment);
 	}
 }).apply(this);


### PR DESCRIPTION
Checks for `module` before `window` for browserify support.
