### PR TITLE
Don't publish tests to npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,17 +1,1 @@
-lib-cov
-*.seed
-*.log
-*.csv
-*.dat
-*.out
-*.pid
-*.gz
-
-pids
-logs
-results
-
-node_modules
-npm-debug.log
-
 tests


### PR DESCRIPTION
When publishing to npm, it's unnecessary to publish all 19 MB of test files.

Sure, tests are nice, but when installing a library I don't expect to run all tests on it. If I discover a bug in it, I clone it from the repo, and run the tests there.

Having to download almost 20 megs of stuff I will never use seems a bit excessive.

Comparatively, the footprint in my node_modules for express is around 640k.
