### PR TITLE
added moment().zoneExists()

### DIFF
--- a/moment-timezone.js
+++ b/moment-timezone.js
@@ -442,6 +442,10 @@
 				mom.zone(offset);
 			}
 		};
+        
+        moment.zoneExists = function (name) {
+            return getZoneSet(name).zones.length > 0;
+        };
 
 		function getZoneSets() {
 			var sets = [],


### PR DESCRIPTION
As a result of an error fired when passing an invalid timezone name to `moment().tz()`

I added the committed code to test for existence of a tz before attempting to localize to it - thought you'd like to see what I did.

I'm sure there's a better way of doing this, but `moment().zoneExists()` wasn't the code I deserved, just the code I needed right now.

Signed-off-by: Mike mike@aviationshake.com
