### PR TITLE
Fix for add/subtract when crossing a tz offset

### DIFF
--- a/moment-timezone.js
+++ b/moment-timezone.js
@@ -447,14 +447,19 @@
 		}
 
 		// overwrite moment.updateOffset
-		moment.updateOffset = function (mom) {
+		moment.updateOffset = function (mom, dontAdjustTime) {
 			var offset;
 			if (mom._z) {
 				offset = mom._z.offset(mom);
-				if (Math.abs(offset) < 16) {
-					offset = offset / 60;
+				if (dontAdjustTime) {
+					mom._offset = offset;
+					mom._isUTC = true;
+				} else {
+					if (Math.abs(offset) < 16) {
+						offset = offset / 60;
+					}
+					mom.zone(offset);
 				}
-				mom.zone(offset);
 			}
 		};
 

--- a/tests/manipulate.js
+++ b/tests/manipulate.js
@@ -1,0 +1,47 @@
+var moment = require("../index");
+
+exports["manipulate"] = {
+  "add" : function (t) {    
+    t.equal(
+      moment('2012-10-28 00:00:00 +01:00').tz('Europe/London').add('days', 1).format(),
+      '2012-10-29T00:00:00+00:00',
+      "adding 1 day while crossing a DST boundary should not affect time (BST -> GMT).");
+    t.equal(
+      moment('2013-11-03T00:00:00-07:00').tz('America/Los_Angeles').add(1, 'day').format(),
+      "2013-11-04T00:00:00-08:00",
+      "adding 1 day while crossing a DST boundary should not affect time (PDT-> PST).");    
+    t.equal(
+      moment("2014-03-09T00:00:00-08:00").tz('America/Los_Angeles').add(1, 'day').format(),
+      "2014-03-10T00:00:00-07:00",
+      "adding 1 day while crossing a DST boundary should not affect time (PST -> PDT).");
+    t.done();
+  },
+  "subtract" : function (t) {
+    t.equal(
+      moment('2012-10-29 00:00:00 +00:00').tz('Europe/London').subtract('days', 1).format(),
+      '2012-10-28T00:00:00+01:00',
+      "subtracting 1 day while crossing a DST boundary should not affect time (GMT -> BST).");
+    t.equal(
+      moment("2013-11-04T00:00:00-08:00").tz('America/Los_Angeles').subtract(1, 'day').format(),
+      '2013-11-03T00:00:00-07:00',
+      "adding 1 day while crossing a DST boundary should not affect time (PST -> PDT).");    
+    t.equal(
+      moment("2014-03-10T00:00:00-07:00").tz('America/Los_Angeles').subtract(1, 'day').format(),
+      "2014-03-09T00:00:00-08:00",
+      "adding 1 day while crossing a DST boundary should not affect time (PDT -> PST).");
+    t.done();
+  },
+  "month" : function (t) {
+    t.equal(
+      moment("2014-03-09T00:00:00-08:00").tz('America/Los_Angeles').add(1, 'month').format(),
+      "2014-04-09T00:00:00-07:00",
+      "adding 1 month while crossing a DST boundary should not affect time (PST -> PDT).");
+    t.equal(
+      moment("2014-03-09T00:00:00-08:00").tz('America/Los_Angeles').month("April").format(),
+      "2014-04-09T00:00:00-07:00",
+      "setting month across a DST boundary should not affect time (PST -> PDT).");
+    
+    t.done();
+  }
+  
+};


### PR DESCRIPTION
When using 'add' or 'subtract' (or maybe other) moment.js functions, result was wrong if date passes through tz offset change.  See discussion in issue #28 for more details.

This commit includes a small suite of tests, along with a small fix in the spirit of that suggested by @icambron [here](https://github.com/moment/moment-timezone/issues/28#issuecomment-25409441): "If we're changing a date or month, just [...] change the offset without touching the time."

This requires an associated change to the moment project (moment/moment#1419), to support this second argument (though it will not fail any harder than it currently does, if running with an older version of moment).
