### PR TITLE
Use zone(z, false) to set the zone without adjusting time

### DIFF
--- a/moment-timezone.js
+++ b/moment-timezone.js
@@ -451,15 +451,10 @@
 			var offset;
 			if (mom._z) {
 				offset = mom._z.offset(mom);
-				if (dontAdjustTime) {
-					mom._offset = offset;
-					mom._isUTC = true;
-				} else {
-					if (Math.abs(offset) < 16) {
-						offset = offset / 60;
-					}
-					mom.zone(offset);
+				if (Math.abs(offset) < 16) {
+					offset = offset / 60;
 				}
+				mom.zone(offset, !dontAdjustTime);
 			}
 		};
 


### PR DESCRIPTION
This is related to https://github.com/moment/moment/pull/1468

This way the interface between moment and moment-timezone is reduced even further.
