### PR TITLE
Configuration for moving ambiguous or invalid input forward or backward

### DIFF
--- a/moment-timezone.js
+++ b/moment-timezone.js
@@ -143,13 +143,26 @@
 			var target  = +timestamp,
 				offsets = this.offsets,
 				untils  = this.untils,
-				i;
+				max     = untils.length - 1,
+				offset, offsetNext, offsetPrev, i;
 
-			for (i = 0; i < untils.length; i++) {
-				if (target < untils[i] - (offsets[i] * 60000)) {
+			for (i = 0; i < max; i++) {
+				offset     = offsets[i];
+				offsetNext = offsets[i + 1];
+				offsetPrev = offsets[i ? i - 1 : i];
+
+				if (offset < offsetNext && tz.moveAmbiguousForward) {
+					offset = offsetNext;
+				} else if (offset > offsetPrev && tz.moveInvalidForward) {
+					offset = offsetPrev;
+				}
+
+				if (target < untils[i] - (offset * 60000)) {
 					return offsets[i];
 				}
 			}
+
+			return offsets[max];
 		},
 
 		abbr : function (mom) {
@@ -272,6 +285,8 @@
 	tz.unpack       = unpack;
 	tz.unpackBase60 = unpackBase60;
 	tz.needsOffset  = needsOffset;
+	tz.moveInvalidForward   = true;
+	tz.moveAmbiguousForward = false;
 
 	/************************************
 		Interface with Moment.js

--- a/tests/moment-timezone/parse.js
+++ b/tests/moment-timezone/parse.js
@@ -5,10 +5,28 @@ var moment = require("../../index");
 var Los_Angeles = "America/Los_Angeles|PST PDT PWT PPT|80 70 70 70|010102301010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010|-261q0 1nX0 11B0 1nX0 SgN0 8x10 iy0 5Wp0 1Vb0 3dB0 WL0 1qN0 11z0 1o10 11z0 1o10 11z0 1o10 11z0 1o10 11z0 1qN0 11z0 1o10 11z0 1o10 11z0 1o10 11z0 1o10 11z0 1qN0 WL0 1qN0 1cL0 1cN0 1cL0 1cN0 1cL0 1cN0 1fz0 1a10 1fz0 1cN0 1cL0 1cN0 1cL0 1cN0 1cL0 1cN0 1cL0 1cN0 1fz0 1cN0 1cL0 1cN0 1cL0 s10 1Vz0 LB0 1BX0 1cN0 1fz0 1a10 1fz0 1cN0 1cL0 1cN0 1cL0 1cN0 1cL0 1cN0 1cL0 1cN0 1fz0 1a10 1fz0 1cN0 1cL0 1cN0 1cL0 1cN0 1cL0 14p0 1lb0 14p0 1nX0 11B0 1nX0 11B0 1nX0 14p0 1lb0 14p0 1lb0 14p0 1nX0 11B0 1nX0 11B0 1nX0 14p0 1lb0 14p0 1lb0 14p0 1lb0 14p0 1nX0 11B0 1nX0 11B0 1nX0 14p0 1lb0 14p0 1lb0 14p0 1nX0 11B0 1nX0 11B0 1nX0 Rd0 1zb0 Op0 1zb0 Op0 1zb0 Rd0 1zb0 Op0 1zb0 Op0 1zb0 Op0 1zb0 Op0 1zb0 Op0 1zb0 Rd0 1zb0 Op0 1zb0 Op0 1zb0 Op0 1zb0 Op0 1zb0 Rd0 1zb0 Op0 1zb0 Op0 1zb0 Op0 1zb0 Op0 1zb0 Op0 1zb0 Rd0 1zb0 Op0 1zb0 Op0 1zb0 Op0 1zb0 Op0 1zb0 Rd0 1zb0 Op0 1zb0 Op0 1zb0 Op0 1zb0 Op0 1zb0 Op0 1zb0";
 var New_York    = "America/New_York|EST EDT EWT EPT|50 40 40 40|01010101010101010101010101010101010101010101010102301010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010|-261t0 1nX0 11B0 1nX0 11B0 1qL0 1a10 11z0 1qN0 WL0 1qN0 11z0 1o10 11z0 1o10 11z0 1o10 11z0 1o10 11z0 1qN0 11z0 1o10 11z0 1o10 11z0 1o10 11z0 1o10 11z0 1qN0 WL0 1qN0 11z0 1o10 11z0 1o10 11z0 1o10 11z0 1o10 11z0 1qN0 WL0 1qN0 11z0 1o10 11z0 RB0 8x40 iv0 1o10 11z0 1o10 11z0 1o10 11z0 1o10 11z0 1qN0 WL0 1qN0 11z0 1o10 11z0 1o10 11z0 1o10 11z0 1o10 1fz0 1cN0 1cL0 1cN0 1cL0 1cN0 1cL0 1cN0 1cL0 1cN0 1fz0 1cN0 1cL0 1cN0 1cL0 1cN0 1cL0 1cN0 1cL0 1cN0 1fz0 1a10 1fz0 1cN0 1cL0 1cN0 1cL0 1cN0 1cL0 1cN0 1cL0 1cN0 1fz0 1cN0 1cL0 1cN0 1cL0 s10 1Vz0 LB0 1BX0 1cN0 1fz0 1a10 1fz0 1cN0 1cL0 1cN0 1cL0 1cN0 1cL0 1cN0 1cL0 1cN0 1fz0 1a10 1fz0 1cN0 1cL0 1cN0 1cL0 1cN0 1cL0 14p0 1lb0 14p0 1nX0 11B0 1nX0 11B0 1nX0 14p0 1lb0 14p0 1lb0 14p0 1nX0 11B0 1nX0 11B0 1nX0 14p0 1lb0 14p0 1lb0 14p0 1lb0 14p0 1nX0 11B0 1nX0 11B0 1nX0 14p0 1lb0 14p0 1lb0 14p0 1nX0 11B0 1nX0 11B0 1nX0 Rd0 1zb0 Op0 1zb0 Op0 1zb0 Rd0 1zb0 Op0 1zb0 Op0 1zb0 Op0 1zb0 Op0 1zb0 Op0 1zb0 Rd0 1zb0 Op0 1zb0 Op0 1zb0 Op0 1zb0 Op0 1zb0 Rd0 1zb0 Op0 1zb0 Op0 1zb0 Op0 1zb0 Op0 1zb0 Op0 1zb0 Rd0 1zb0 Op0 1zb0 Op0 1zb0 Op0 1zb0 Op0 1zb0 Rd0 1zb0 Op0 1zb0 Op0 1zb0 Op0 1zb0 Op0 1zb0 Op0 1zb0";
 
+var moveAmbiguousForward, moveInvalidForward;
+
 exports.parse = {
 	setUp : function (done) {
 		moment.tz.add([Los_Angeles, New_York]);
+
+		moveAmbiguousForward = moment.tz.moveAmbiguousForward;
+		moveInvalidForward = moment.tz.moveInvalidForward;
 		done();
+	},
+
+	tearDown : function (done) {
+		moment.tz.moveAmbiguousForward = moveAmbiguousForward;
+		moment.tz.moveInvalidForward = moveInvalidForward;
+		done();
+	},
+
+	"default states" : function (t) {
+		t.ok(moment.tz.moveInvalidForward,    "Should default to moving invalid input forward");
+		t.ok(!moment.tz.moveAmbiguousForward, "Should default to moving ambiguous input backward");
+
+		t.done();
 	},
 
 	"invalid input - moveInvalidForward = false - Los Angeles" : function (t) {
@@ -56,7 +74,7 @@ exports.parse = {
 	},
 
 	"invalid input - moveInvalidForward = true - Los Angeles" : function (t) {
-		moment.tz.moveInvalidForward = true;
+		// moment.tz.moveInvalidForward = true; Should default to true
 
 		// the hour from 2am to 3am does not exist on March 11 2011 in America/Los_Angeles
 		var before  = moment.tz([2012, 2, 11, 1, 59, 59], "America/Los_Angeles"),
@@ -78,7 +96,7 @@ exports.parse = {
 	},
 
 	"invalid input - moveInvalidForward = true - New York" : function (t) {
-		moment.tz.moveInvalidForward = true;
+		// moment.tz.moveInvalidForward = true; Should default to true
 
 		// the hour from 2am to 3am does not exist on March 11 2011 in America/New_York
 		var before  = moment.tz([2012, 2, 11, 1, 59, 59], "America/New_York"),
@@ -100,7 +118,7 @@ exports.parse = {
 	},
 
 	"ambiguous input - moveAmbiguousForward = false - Los Angeles" : function (t) {
-		moment.tz.moveAmbiguousForward = false;
+		// moment.tz.moveAmbiguousForward = false; Should default to false
 
 		// the hour from 1am to 2am happens twice on Nov 4 2011 in America/Los_Angeles
 		var before  = moment.tz([2012, 10, 4, 0, 59, 59], "America/Los_Angeles"),
@@ -122,7 +140,7 @@ exports.parse = {
 	},
 
 	"ambiguous input - moveAmbiguousForward = false - New York" : function (t) {
-		moment.tz.moveAmbiguousForward = false;
+		// moment.tz.moveAmbiguousForward = false; Should default to false
 
 		// the hour from 1am to 2am happens twice on Nov 4 2011 in America/Los_Angeles
 		var before  = moment.tz([2012, 10, 4, 0, 59, 59], "America/New_York"),
@@ -206,5 +224,5 @@ exports.parse = {
 		}
 
 		t.done();
-	},
+	}
 };

--- a/tests/moment-timezone/zone.js
+++ b/tests/moment-timezone/zone.js
@@ -5,7 +5,21 @@ var tz = require("../../").tz;
 // gE = 1000; 1E = 100; 2k = 140
 var PACKED = "SomeZone|TIM TAM IAM|60.u 50 60|012101|gE 1E 2k 1E 2k";
 
+var moveAmbiguousForward, moveInvalidForward;
+
 exports.zone = {
+	setUp : function (done) {
+		moveAmbiguousForward = tz.moveAmbiguousForward;
+		moveInvalidForward = tz.moveInvalidForward;
+		done();
+	},
+
+	tearDown : function (done) {
+		tz.moveAmbiguousForward = moveAmbiguousForward;
+		tz.moveInvalidForward = moveInvalidForward;
+		done();
+	},
+
 	construct : function (test) {
 		var zone = new tz.Zone(PACKED);
 
@@ -120,6 +134,8 @@ exports.zone = {
 				[(1479 - 360.5) * 60000, 360.5],
 				[(1480 - 360.5) * 60000, 300]
 			], i, source, expected;
+
+		tz.moveInvalidForward = false;
 
 		for (i = 0; i < tests.length; i++) {
 			source = tests[i][0];


### PR DESCRIPTION
This is the fix for #99. /cc @mj1856

The defaults are to move ambiguous input backward and invalid input forward.

``` js
moment.tz.moveInvalidForward;   // true
moment.tz.moveAmbiguousForward; // false
```

Ambiguous input

``` js
moment.tz.moveAmbiguousForward; // false
moment.tz([2012, 10, 4, 0, 30], "America/New_York").format() // 2012-11-04T00:30:00-04:00
moment.tz([2012, 10, 4, 1, 30], "America/New_York").format() // 2012-11-04T01:30:00-04:00
moment.tz([2012, 10, 4, 2, 30], "America/New_York").format() // 2012-11-04T02:30:00-05:00
moment.tz.moveAmbiguousForward = true;
moment.tz([2012, 10, 4, 0, 30], "America/New_York").format() // 2012-11-04T00:30:00-04:00
moment.tz([2012, 10, 4, 1, 30], "America/New_York").format() // 2012-11-04T01:30:00-05:00
moment.tz([2012, 10, 4, 2, 30], "America/New_York").format() // 2012-11-04T02:30:00-05:00
```

Invalid input

``` js
moment.tz.moveInvalidForward; // true
moment.tz([2012, 2, 11, 1, 30], "America/New_York").format(); // 2012-03-11T01:30:00-05:00
moment.tz([2012, 2, 11, 2, 30], "America/New_York").format(); // 2012-03-11T03:30:00-04:00
moment.tz([2012, 2, 11, 3, 30], "America/New_York").format(); // 2012-03-11T03:30:00-04:00
moment.tz.moveInvalidForward = false;
moment.tz([2012, 2, 11, 1, 30], "America/New_York").format(); // 2012-03-11T01:30:00-05:00
moment.tz([2012, 2, 11, 2, 30], "America/New_York").format(); // 2012-03-11T01:30:00-05:00
moment.tz([2012, 2, 11, 3, 30], "America/New_York").format(); // 2012-03-11T03:30:00-04:00
```
