### PR TITLE
Make links into actual Zone objects instead of just referencing the linked Zone

### DIFF
--- a/tests/moment-timezone/link.js
+++ b/tests/moment-timezone/link.js
@@ -2,19 +2,32 @@
 
 var tz = require("../../").tz;
 
-function clearObject (obj) {
+var tempLinks = {},
+	tempZones = {};
+
+function moveProperties (a, b) {
 	var key;
-	for (key in obj) {
-		if (obj.hasOwnProperty(key)) {
-			delete obj[key];
+	for (key in a) {
+		if (a.hasOwnProperty(key)) {
+			b[key] = a[key];
+			delete a[key];
 		}
 	}
+
 }
 
 exports.link = {
 	setUp : function (done) {
-		clearObject(tz._links);
-		clearObject(tz._zones);
+		moveProperties(tz._links, tempLinks);
+		moveProperties(tz._zones, tempZones);
+		done();
+	},
+
+	tearDown : function (done) {
+		moveProperties(tz._links, {});
+		moveProperties(tz._zones, {});
+		moveProperties(tempLinks, tz._links);
+		moveProperties(tempZones, tz._zones);
 		done();
 	},
 
@@ -39,9 +52,9 @@ exports.link = {
 		test.ok(tz.zone('Alias3'), "Should be able to add an alias with ['Alias|Zone'] format");
 
 		test.equal(tz.zone('Zone1').name,  'Zone1', "Should get the right zone.");
-		test.equal(tz.zone('Alias1').name, 'Zone1', "Should get the right zone from an alias.");
-		test.equal(tz.zone('Alias2').name, 'Zone1', "Should get the right zone from an alias.");
-		test.equal(tz.zone('Alias3').name, 'Zone1', "Should get the right zone from an alias.");
+		test.equal(tz.zone('Alias1').name, 'Alias1', "Should get the right zone from an alias.");
+		test.equal(tz.zone('Alias2').name, 'Alias2', "Should get the right zone from an alias.");
+		test.equal(tz.zone('Alias3').name, 'Alias3', "Should get the right zone from an alias.");
 
 		test.done();
 	},
@@ -67,9 +80,9 @@ exports.link = {
 		test.ok(tz.zone('Alias3'), "Should be able to add an alias with ['Zone|Alias'] format");
 
 		test.equal(tz.zone('Zone1').name,  'Zone1', "Should get the right zone.");
-		test.equal(tz.zone('Alias1').name, 'Zone1', "Should get the right zone from an alias.");
-		test.equal(tz.zone('Alias2').name, 'Zone1', "Should get the right zone from an alias.");
-		test.equal(tz.zone('Alias3').name, 'Zone1', "Should get the right zone from an alias.");
+		test.equal(tz.zone('Alias1').name, 'Alias1', "Should get the right zone from an alias.");
+		test.equal(tz.zone('Alias2').name, 'Alias2', "Should get the right zone from an alias.");
+		test.equal(tz.zone('Alias3').name, 'Alias3', "Should get the right zone from an alias.");
 
 		test.done();
 	},
@@ -87,10 +100,32 @@ exports.link = {
 		test.ok(tz.zone('Alias1'), "Should be able to add an alias before adding the zone.");
 
 		test.equal(tz.zone('Zone1').name,  'Zone1', "Should get the right zone.");
-		test.equal(tz.zone('Alias1').name, 'Zone1', "Should get the right zone from an alias.");
+		test.equal(tz.zone('Alias1').name, 'Alias1', "Should get the right zone from an alias.");
 
 		tz.link("Alias2|Zone2");
 		test.ok(!tz.zone('Alias2'), "Aliases without zones should be null.");
+
+		test.done();
+	},
+
+	namesOfAliases : function (test) {
+		test.ok(!tz.zone('Zone1'),  "Zones should have been reset.");
+		test.ok(!tz.zone('Alias1'), "Links should have been reset.");
+		test.ok(!tz.zone('Alias2'), "Links should have been reset.");
+		test.ok(!tz.zone('Alias3'), "Links should have been reset.");
+
+		tz.link("Alias1|Zone1");
+		tz.add("Zone1|ASDF|0|0|0");
+		test.deepEqual(tz.names(), ["Alias1", "Zone1"], "Should be able to get the names of aliased zones.");
+
+		tz.link("Alias2|Zone1");
+		test.deepEqual(tz.names(), ["Alias1", "Alias2", "Zone1"], "Should be able to get the names of aliased zones.");
+
+		tz.link("Alias3|Zone2");
+		test.deepEqual(tz.names(), ["Alias1", "Alias2", "Zone1"], "Should be able to get the names of aliased zones.");
+
+		tz.link("Alias3|Zone1");
+		test.deepEqual(tz.names(), ["Alias1", "Alias2", "Alias3", "Zone1"], "Should be able to get the names of aliased zones.");
 
 		test.done();
 	}


### PR DESCRIPTION
Instead of just doing a lookup in the `getZone` method, this will create a new `Zone` for each link.

Fixes #102 and #103.
