### PR TITLE
Forward all moment.utc arguments from wrapper

### DIFF
--- a/moment-timezone.js
+++ b/moment-timezone.js
@@ -369,7 +369,7 @@
 	function resetZoneWrap (old) {
 		return function () {
 			this._z = null;
-			return old.call(this);
+			return old.apply(this, arguments);
 		};
 	}
 


### PR DESCRIPTION
Now `momen().utc()` (moment 2.8.1) receives arguments, make sure those are forwarded in the `resetZoneWrap`.
