### PR TITLE
Add check for momentProperties to avoid uncaught exception

### DIFF
--- a/moment-timezone.js
+++ b/moment-timezone.js
@@ -383,9 +383,12 @@
 		// moment 2.8.1+
 		momentProperties.push('_z');
 		momentProperties.push('_a');
-	} else {
+	} else if(momentProperties) {
 		// moment 2.7.0
 		momentProperties._z = null;
+	} else{
+		// moment < 2.6 - unsupported
+		console.error("moment-timezone.js: Your version of moment is unsupported.  moment-timezone requires moment.js 2.6+ go to http://momentjs.com to get the newest version.");
 	}
 
 	// INJECT DATA


### PR DESCRIPTION
I had an error where it said _z is undefined. This took me about 5 minutes to breakpoint the code, which lead me back to the site where I found moment 2.6 was required. Because this threw an uncaught error other items broke like not being able to load data. By having if statement you get the benefit of

1 - No uncaught exception where user is confused
2 - User gets a helpful message in their console and a link to correct the dependency

Thanks for the great library!
