### PR TITLE
make sure normalizeName argument is a string

### DIFF
--- a/moment-timezone.js
+++ b/moment-timezone.js
@@ -193,7 +193,9 @@
 	************************************/
 
 	function normalizeName (name) {
-		return (name || '').toLowerCase().replace(/\//g, '_');
+		if (typeof name !== 'string')
+			name = '';
+		return name.toLowerCase().replace(/\//g, '_');
 	}
 
 	function addZone (packed) {


### PR DESCRIPTION
In case I submit number as a timezone name, function throws an error.
