### PR TITLE
Fix for error "stderr: maxBuffer exceeded", while running `data-zdump` grunt task

### DIFF
--- a/tasks/data-zdump.js
+++ b/tasks/data-zdump.js
@@ -22,7 +22,7 @@ module.exports = function (grunt) {
 				src  = path.join(zicBase, file),
 				dest = path.join(zdumpBase, file);
 
-			exec('zdump -v ' + src, function (err, stdout) {
+			exec('zdump -v ' + src, { maxBuffer: 20*1024*1024 }, function (err, stdout) {
 				if (err) { throw err; }
 
 				grunt.file.mkdir(path.dirname(dest));


### PR DESCRIPTION
While running `grunt release` command on the latest `develop` branch head, ran into issue for the `data-zdump` task.

```
stderr: maxBuffer exceeded
```

The grunt exec command has an option to bump the stdout buffer size, and that resolved the issue.
