### PR TITLE
add main file mapping for jspm

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,9 @@
 		"grunt-contrib-jshint"   : "0.10.0",
 		"grunt-contrib-uglify"   : "0.4.0"
 	},
+	"jspm" : {
+		"main": "builds/moment-timezone-with-data"
+	},
 	"scripts": {
 		"test": "grunt"
 	}


### PR DESCRIPTION
I using [JSPM] to manage my dependence.

[JSPM] using [SystemJS] for loading library.

BUT, in `index.js`
```
var moment = module.exports = require("./moment-timezone");
moment.tz.load(require('./data/packed/latest.json'));
```

[SystemJS] didn't support `require('./data/packed/latest.json')'` for load json.

My fix:

I add [JSPM] options in package.json, make [JSPM] using `builds/moment-timezone-with-data.js` instead of `index.js`

Then everything is works for me.

[JSPM]:https://github.com/jspm/jspm-cli
[SystemJS]:https://github.com/jspm/jspm-cli




