### PR TITLE
unpack only what needed

### DIFF
--- a/moment-timezone.js
+++ b/moment-timezone.js
@@ -24,6 +24,7 @@
 	var VERSION = "0.3.1",
 		zones = {},
 		links = {},
+		zonesByName = {},
 
 		momentVersion = moment.version.split('.'),
 		major = +momentVersion[0],
@@ -212,6 +213,9 @@
 	}
 
 	function getZone (name) {
+		if( zonesByName[name] && !zones[name] ){
+			addZone( zonesByName[name] );
+		}
 		return zones[normalizeName(name)] || null;
 	}
 
@@ -275,9 +279,21 @@
 	}
 
 	function loadData (data) {
-		addZone(data.zones);
-		addLink(data.links);
 		tz.dataVersion = data.version;
+		addLink(data.links);
+		var zonesPacked = data.zones, i, zone, zoneParts;
+
+		if (typeof zonesPacked === "string") {
+			zonesPacked = [zonesPacked];
+		}
+
+		for (i = 0; i < zonesPacked.length; i++) {
+			zone = zonesPacked[i];
+			if( zone ){
+				zoneParts = zone.split('|');
+				zonesByName[zoneParts[0]] = zone;
+			}
+		}
 	}
 
 	function zoneExists (name) {

--- a/moment-timezone.js
+++ b/moment-timezone.js
@@ -281,7 +281,7 @@
 	function loadData (data) {
 		tz.dataVersion = data.version;
 		addLink(data.links);
-		var zonesPacked = data.zones, i, zone, zoneParts;
+		var zonesPacked = data.zones, linksPacked = data.links, i, l, link, zone, zoneParts, linkParts;
 
 		if (typeof zonesPacked === "string") {
 			zonesPacked = [zonesPacked];
@@ -292,6 +292,14 @@
 			if( zone ){
 				zoneParts = zone.split('|');
 				zonesByName[zoneParts[0]] = zone;
+			}
+		}
+
+		if( linksPacked ){
+			for (l = 0; l < linksPacked.length; l++) {
+				link = linksPacked[l];
+				linkParts = link.split('|');
+				zonesByName[linkParts[1]] = zonesByName[linkParts[0]];
 			}
 		}
 	}


### PR DESCRIPTION
Only execute the unpack for the one timezone if it hasn't been done already. Based on some testing, on initial load desktop is around ~2ms, and Chrome Android ~30 now

Previously the multiple unpacks were really expensive on mobile

![screenshot 2015-05-06 12 28 04](https://cloud.githubusercontent.com/assets/317856/7504205/68550b96-f416-11e4-868d-ba3fdb8c7db6.png)