### PR TITLE
Unpack only what needed (alternate approach)

### DIFF
--- a/moment-timezone.js
+++ b/moment-timezone.js
@@ -129,13 +129,21 @@
 
 	function Zone (packedString) {
 		if (packedString) {
-			this._set(unpack(packedString));
+			this.packed = packedString;
+			this.name = packedString.split('|')[0];
 		}
 	}
 
 	Zone.prototype = {
+		unpack : function () {
+			if (this.packed) {
+				this._set(unpack(this.packed));
+				this.packed = null;
+			}
+			return this;
+		},
+
 		_set : function (unpacked) {
-			this.name    = unpacked.name;
 			this.abbrs   = unpacked.abbrs;
 			this.untils  = unpacked.untils;
 			this.offsets = unpacked.offsets;
@@ -212,7 +220,8 @@
 	}
 
 	function getZone (name) {
-		return zones[normalizeName(name)] || null;
+		var zone = zones[normalizeName(name)];
+		return zone && zone.unpack() || null;
 	}
 
 	function getNames () {
@@ -259,7 +268,11 @@
 
 	function copyZoneWithName (zone, name) {
 		var linkZone = zones[normalizeName(name)] = new Zone();
-		linkZone._set(zone);
+		if (zone.packed) {
+			linkZone.packed = zone.packed;
+		} else {
+			linkZone._set(zone);
+		}
 		linkZone.name = name;
 	}
 
@@ -267,7 +280,7 @@
 		zoneName = normalizeName(zoneName);
 
 		if (zones[zoneName]) {
-			copyZoneWithName(zones[zoneName], linkName);
+			copyZoneWithName(zones[zoneName].unpack(), linkName);
 		} else {
 			links[zoneName] = links[zoneName] || [];
 			links[zoneName].push(linkName);

--- a/tests/moment-timezone/zone.js
+++ b/tests/moment-timezone/zone.js
@@ -21,7 +21,7 @@ exports.zone = {
 	},
 
 	construct : function (test) {
-		var zone = new tz.Zone(PACKED);
+		var zone = new tz.Zone(PACKED).unpack();
 
 		test.equal(zone.name, "SomeZone", "Should unpack name onto .name property.");
 		test.deepEqual(zone.abbrs, ["TIM", "TAM", "IAM", "TAM", "TIM", "TAM"], "Should unpack abbrs onto .abbrs property.");
@@ -39,7 +39,7 @@ exports.zone = {
 	},
 
 	abbr : function (test) {
-		var zone = new tz.Zone(PACKED),
+		var zone = new tz.Zone(PACKED).unpack(),
 			tests = [
 				[-999 * 60000, "TIM"],
 				[ 999 * 60000, "TIM"],
@@ -65,7 +65,7 @@ exports.zone = {
 	},
 
 	offset : function (test) {
-		var zone = new tz.Zone(PACKED),
+		var zone = new tz.Zone(PACKED).unpack(),
 			tests = [
 				[-999 * 60000, 360.5],
 				[ 999 * 60000, 360.5],
@@ -91,7 +91,7 @@ exports.zone = {
 	},
 
 	_index : function (test) {
-		var zone = new tz.Zone(PACKED),
+		var zone = new tz.Zone(PACKED).unpack(),
 			tests = [
 				[-999 * 60000, 0],
 				[ 999 * 60000, 0],
@@ -117,7 +117,7 @@ exports.zone = {
 	},
 
 	parse : function (test) {
-		var zone = new tz.Zone(PACKED),
+		var zone = new tz.Zone(PACKED).unpack(),
 			tests = [
 				[( 999 - 360.5) * 60000, 360.5],
 				[(1000 - 360.5) * 60000, 300],


### PR DESCRIPTION
Alternate approach to #211

Store the packed string and name on the Zone object.

When the zone is requested, either from getZone or pushLink, the data is unpacked if needed.
The packed property is then reset to ensure that data is not being re-unpacked.

This method ensures that the data is available whether the link or zone used first. See http://jsfiddle.net/3tj066w7/1/

This approach is not nearly as fast as the one in #211, but we should check again after fixing the load order issue.

Perf improvements for this approach. http://jsperf.com/moment-timezone-unpack-on-demand

Perf improvements for the #211 approach. http://jsperf.com/moment-timezone-unpack-on-demand-2