### PR TITLE
Restructure zone getter to allow for lazy unpacking.

### DIFF
--- a/moment-timezone.js
+++ b/moment-timezone.js
@@ -242,7 +242,7 @@
 		var i, out = [];
 
 		for (i in names) {
-			if (names.hasOwnProperty(i) && names[i]) {
+			if (names.hasOwnProperty(i) && (zones[i] || zones[links[i]]) && names[i]) {
 				out.push(names[i]);
 			}
 		}
@@ -251,7 +251,7 @@
 	}
 
 	function addLink (aliases) {
-		var i, alias;
+		var i, alias, normal0, normal1;
 
 		if (typeof aliases === "string") {
 			aliases = [aliases];
@@ -259,15 +259,16 @@
 
 		for (i = 0; i < aliases.length; i++) {
 			alias = aliases[i].split('|');
-			pushLink(alias[0], alias[1]);
-			pushLink(alias[1], alias[0]);
-		}
-	}
 
-	function pushLink (zoneName, linkName) {
-		var name = normalizeName(linkName);
-		links[name] = zoneName;
-		names[name] = linkName;
+			normal0 = normalizeName(alias[0]);
+			normal1 = normalizeName(alias[1]);
+
+			links[normal0] = normal1;
+			names[normal0] = alias[0];
+
+			links[normal1] = normal0;
+			names[normal1] = alias[1];
+		}
 	}
 
 	function loadData (data) {

--- a/moment-timezone.js
+++ b/moment-timezone.js
@@ -212,7 +212,7 @@
 		}
 	}
 
-	function getZone (name) {
+	function getZone (name, caller) {
 		name = normalizeName(name);
 
 		var zone = zones[name];
@@ -228,7 +228,8 @@
 			return zone;
 		}
 
-		if (links[name] && (link = getZone(links[name]))) {
+		// Pass getZone to prevent recursion more than 1 level deep
+		if (links[name] && caller !== getZone && (link = getZone(links[name], getZone))) {
 			zone = zones[name] = new Zone();
 			zone._set(link);
 			zone.name = names[name];

--- a/tests/moment-timezone/link.js
+++ b/tests/moment-timezone/link.js
@@ -132,5 +132,17 @@ exports.link = {
 		test.deepEqual(tz.names(), ["Alias1", "Alias2", "Alias3", "Zone1"], "Should be able to get the names of aliased zones.");
 
 		test.done();
+	},
+
+	zoneAndAliasNotLoaded : function (test) {
+		test.ok(!tz.zone('Zone1'),  "Zones should have been reset.");
+		test.ok(!tz.zone('Alias1'), "Links should have been reset.");
+
+		tz.link("Alias1|Zone1");
+
+		test.ok(!tz.zone('Zone1'),  "Zone should not exist if it wasn't loaded.");
+		test.ok(!tz.zone('Alias1'), "Link should not exist if its zone wasn't loaded.");
+
+		test.done();
 	}
 };

--- a/tests/moment-timezone/link.js
+++ b/tests/moment-timezone/link.js
@@ -3,7 +3,8 @@
 var tz = require("../../").tz;
 
 var tempLinks = {},
-	tempZones = {};
+	tempZones = {},
+	tempNames = {};
 
 function moveProperties (a, b) {
 	var key;
@@ -20,14 +21,17 @@ exports.link = {
 	setUp : function (done) {
 		moveProperties(tz._links, tempLinks);
 		moveProperties(tz._zones, tempZones);
+		moveProperties(tz._names, tempNames);
 		done();
 	},
 
 	tearDown : function (done) {
 		moveProperties(tz._links, {});
 		moveProperties(tz._zones, {});
+		moveProperties(tz._names, {});
 		moveProperties(tempLinks, tz._links);
 		moveProperties(tempZones, tz._zones);
+		moveProperties(tempNames, tz._names);
 		done();
 	},
 

--- a/tests/moment-timezone/names.js
+++ b/tests/moment-timezone/names.js
@@ -15,6 +15,7 @@ exports.names = {
 	setUp : function (done) {
 		clearObject(tz._links);
 		clearObject(tz._zones);
+		clearObject(tz._names);
 		done();
 	},
 


### PR DESCRIPTION
Another alternative to #211 and #215.

This approach is much closer to the approach in #211, but cleans up a bunch of internals in the process.

We load data like below. This is the example at https://jsfiddle.net/rn58wmvn/3/.

```js
moment.tz.load({
    version: "2015a",
	zones: [ "America/Chicago|CST CDT|60 50|01010101010101010101010|1BQU0 1zb0 Op0 1zb0 Op0 1zb0 Op0 1zb0 Op0 1zb0 Op0 1zb0 Rd0 1zb0 Op0 1zb0 Op0 1zb0 Op0 1zb0 Op0 1zb0"],
    links: ["America/Chicago|US/Central"]
});
```

The internal representation looks like this.

```js
var links = {
  america_chicago: 'us_central',
  us_central: 'america_chicago'
};
var zones = {
  america_chicago: 'America/Chicago|CST CDT|60 50|0101010101010101...'
};
var names = {
  america_chicago: 'America/Chicago',
  us_central: 'US/Central'
};
```

Now we try to load the data for `US/Central`.

We check if there is an unpacked zone for `us_central`. There is not, so we continue.

We then check if there is a packed string for `us_central`. There is not, so we continue.

We then check if there is a link for `us_central`. There is a link, `america_chicago`, so we call `getZone` on `america_chicago`.

We check if there is an unpacked zone for `america_chicago`. There is not, so we continue.

We then check if there is a packed string for `america_chicago`. There is, so we unpack it. The data now looks like this.

```js
var links = {
  america_chicago: 'us_central',
  us_central: 'america_chicago'
};
var zones = {
  america_chicago: Zone(name: 'America/Chicago', abbrs: ['CST', 'CDT', '...'])
};
var names = {
  america_chicago: 'America/Chicago',
  us_central: 'US/Central'
};
```

That zone is returned to the function looking for the `us_central` zone, and we use that and the `names` hash to populate the new zone. The data looks like this.

```js
var links = {
  america_chicago: 'us_central',
  us_central: 'america_chicago'
};
var zones = {
  america_chicago: Zone(name: 'America/Chicago', abbrs: ['CST', 'CDT', '...'])
  us_central: Zone(name: 'US/Central', abbrs: ['CST', 'CDT', '...'])
};
var names = {
  america_chicago: 'America/Chicago',
  us_central: 'US/Central'
};
```

Subsequent calls to get the zone for `America/Chicago` and `US/Central` will now be short-circuted by the [check for an unpacked zone](https://github.com/moment/moment-timezone/compare/develop...timrwood:unpack-on-demand-2?expand=1#diff-dc6222d578e253f8b8b2cfb8db3b36a0R221).

The perf for this approach is roughly the same for the approach in #211.

This approach. http://jsperf.com/moment-timezone-unpack-on-demand/5

#211 approach. http://jsperf.com/moment-timezone-unpack-on-demand-2/2

I've only tested on a couple desktop browsers, so it would be good to see if the same perf improvements seen on android with @davidpean's implementation are applied here as well. cc @paulirish