### PR TITLE
Fix parsing into a default zone.

### DIFF
--- a/moment-timezone.js
+++ b/moment-timezone.js
@@ -345,9 +345,15 @@
 	moment.defaultZone = null;
 
 	moment.updateOffset = function (mom, keepTime) {
-		var offset;
+		var zone = moment.defaultZone,
+			offset;
+
 		if (mom._z === undefined) {
-			mom._z = moment.defaultZone;
+			if (zone && needsOffset(mom) && !mom._isUTC) {
+				mom._d = moment.utc(mom._a)._d;
+				mom.utc().add(zone.parse(mom), 'minutes');
+			}
+			mom._z = zone;
 		}
 		if (mom._z) {
 			offset = mom._z.offset(mom);

--- a/tests/moment-timezone/parse.js
+++ b/tests/moment-timezone/parse.js
@@ -20,6 +20,7 @@ exports.parse = {
 	tearDown : function (done) {
 		moment.tz.moveAmbiguousForward = moveAmbiguousForward;
 		moment.tz.moveInvalidForward = moveInvalidForward;
+		moment.tz.setDefault(null);
 		done();
 	},
 
@@ -238,6 +239,28 @@ exports.parse = {
 				[moment.tz(new Date(1338523200000), name),     "2012-06-01 00:00:00 -04:00", "new Date(1338534000000)"],
 				[moment.tz({y : 2012, M : 5, d : 1}, name),    "2012-06-01 00:00:00 -04:00", "{y : 2012, M : 5, d : 1}"],
 				[moment.tz(moment.utc([2012, 5, 1, 4]), name), "2012-06-01 00:00:00 -04:00", "moment.utc([2012, 5, 1, 4])"]
+			], i, actual, message, expected;
+
+		for (i = 0; i < tests.length; i++) {
+			actual   = tests[i][0].format('YYYY-MM-DD HH:mm:ss Z');
+			expected = tests[i][1];
+			message  = tests[i][2];
+			t.equal(actual, expected, "Parsing " + message + " in America/New_York should equal " + expected);
+		}
+
+		t.done();
+	},
+
+	"parse in default zone" : function (t) {
+		moment.tz.setDefault("America/New_York");
+
+		var tests = [
+				[moment([2012, 5, 1]),                "2012-06-01 00:00:00 -04:00", "[2012, 5, 1]"],
+				[moment("2012-06-01"),                "2012-06-01 00:00:00 -04:00", "2012-06-01"],
+				[moment("2012-06-01 04:00:00+00:00"), "2012-06-01 00:00:00 -04:00", "2012-06-01 00:00:00+00:00"],
+				[moment(1338523200000),               "2012-06-01 00:00:00 -04:00", "1338534000000"],
+				[moment(new Date(1338523200000)),     "2012-06-01 00:00:00 -04:00", "new Date(1338534000000)"],
+				[moment({y : 2012, M : 5, d : 1}),    "2012-06-01 00:00:00 -04:00", "{y : 2012, M : 5, d : 1}"]
 			], i, actual, message, expected;
 
 		for (i = 0; i < tests.length; i++) {


### PR DESCRIPTION
This addresses the bugs in #197.

When parsing with `moment()` instead of `moment.tz()` into a default timezone, the input was being parsed into local time and then the timezone was changed in place.

This accounts for parsing into local time and changes the offset accordingly to retain the correct time, offset, and timezone.

http://jsfiddle.net/jj0s0s1m/2/

```js
moment.tz.setDefault("America/Los_Angeles");
moment("2015-03-26");                           // 2015-03-26T00:00:00-07:00
moment("2015-03-26 00:00");                     // 2015-03-26T00:00:00-07:00
moment("09.04.2015 22:22", "DD.MM.YYYY HH:mm"); // 2015-04-09T22:22:00-07:00

moment.tz.setDefault("America/New_York");
moment("2015-03-26");                           // 2015-03-26T00:00:00-04:00
moment("2015-03-26 00:00");                     // 2015-03-26T00:00:00-04:00
moment("09.04.2015 22:22", "DD.MM.YYYY HH:mm"); // 2015-04-09T22:22:00-04:00
```