### PR TITLE
Log an error if moment timezone was already loaded. #212

### DIFF
--- a/moment-timezone.js
+++ b/moment-timezone.js
@@ -19,7 +19,10 @@
 	"use strict";
 
 	// Do not load moment-timezone a second time.
-	if (moment.tz !== undefined) { return moment; }
+	if (moment.tz !== undefined) {
+		logError('Moment Timezone ' + moment.tz.version + ' was already loaded ' + (moment.tz.dataVersion ? 'with data from ' : 'without any data') + moment.tz.dataVersion);
+		return moment;
+	}
 
 	var VERSION = "0.3.1",
 		zones = {},


### PR DESCRIPTION
This adds an error message when loading moment-timezone twice. This addresses #212.

http://jsfiddle.net/eLh5m79c/

![image](https://cloud.githubusercontent.com/assets/643885/7589218/1bf831ae-f887-11e4-9a74-fda6fb43cec2.png)