### PR TITLE
Fix #195: Include builds dir in npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -9,7 +9,6 @@ contributing.md
 .travis.yml
 .jshintrc
 
-builds
 bower.json
 
 data/unpacked/*.json


### PR DESCRIPTION
This makes it possible for people who use npm for browser-side package
management to use moment-timezone directly without having to build it.