### PR TITLE
Remove invalid jspm configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,9 +36,6 @@
 		"grunt-contrib-jshint"   : "0.11.2",
 		"grunt-contrib-uglify"   : "0.9.1"
 	},
-	"jspm" : {
-		"main": "builds/moment-timezone-with-data"
-	},
 	"scripts": {
 		"test": "grunt"
 	}


### PR DESCRIPTION
The NPM package is not published with `builds/moment-timezone-with-data` so it's an error to specify it as the main file. It also appears to confuse jspm which tries to import `moment-timezone.js` instead of `index.js` (which is required as it loads the necessary data). Removing this invalid configuration will make jspm import the correct file (`index.js`).

Ping @chenzhenxi (committer of the `jspm` config) in case you have any objections