### PR TITLE
Fix issue when an element with ID of `exports` is defined in the browser.

### DIFF
--- a/moment-timezone-utils.js
+++ b/moment-timezone-utils.js
@@ -10,7 +10,7 @@
 	/*global define*/
 	if (typeof define === 'function' && define.amd) {
 		define(['moment'], factory);                 // AMD
-	} else if (typeof exports === 'object') {
+	} else if (typeof module === 'object' && module.exports) {
 		module.exports = factory(require('./'));     // Node
 	} else {
 		factory(root.moment);                        // Browser

--- a/moment-timezone.js
+++ b/moment-timezone.js
@@ -10,7 +10,7 @@
 	/*global define*/
 	if (typeof define === 'function' && define.amd) {
 		define(['moment'], factory);                 // AMD
-	} else if (typeof exports === 'object') {
+	} else if (typeof module === 'object' && module.exports) {
 		module.exports = factory(require('moment')); // Node
 	} else {
 		factory(root.moment);                        // Browser


### PR DESCRIPTION
Elements with IDs automatically have their IDs exposed. This causes errors where `module` is not defined, and yet `module.exports = moment-timezone` is run.

If possible, could you release this as a patch release?