### PR TITLE
Fixes/incorrect minimum moment version

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 	"jspm" : {
 		"main": "builds/moment-timezone-with-data",
 		"dependencies": {
-			"moment": ">= 2.9.0"
+			"moment": "^2.9.0"
 		},
 		"shim": {
 			"moment-timezone": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 	"jspm" : {
 		"main": "builds/moment-timezone-with-data",
 		"dependencies": {
-			"moment": "~2.6.0"
+			"moment": ">= 2.9.0"
 		},
 		"shim": {
 			"moment-timezone": {


### PR DESCRIPTION
Fix the moment library dependency version to match with Bower.

This will fix issue #269.