### PR TITLE
Remove jspm deps so that the root package.json deps are used.

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,9 +38,6 @@
 	},
 	"jspm" : {
 		"main": "builds/moment-timezone-with-data",
-		"dependencies": {
-			"moment": "~2.6.0"
-		},
 		"shim": {
 			"moment-timezone": {
 				"deps": ["moment"]


### PR DESCRIPTION
> You can write all package properties at the base of the package.json, or if you don't want to change existing properties that you'd like to use specifically for npm, you can write your jspm-specific configuration inside the jspm property of package.json, and jspm will use these options over the root level configuration options.

https://github.com/jspm/registry/wiki/Configuring-Packages-for-jspm#prefixing-configuration

I think we can just drop the `jspm.dependencies` property and jspm will use the root `dependencies` configuration.

Addresses #280 and #269.