### PR TITLE
Use Intl API for guessing when available

### DIFF
--- a/moment-timezone.js
+++ b/moment-timezone.js
@@ -344,6 +344,10 @@
 		return cachedGuess;
 	}
 
+	function isFunction(input) {
+		return input instanceof Function || Object.prototype.toString.call(input) === '[object Function]';
+	}
+
 	/************************************
 		Global Methods
 	************************************/

--- a/moment-timezone.js
+++ b/moment-timezone.js
@@ -318,6 +318,15 @@
 	}
 
 	function rebuildGuess () {
+
+		// use Intl API when available and returning valid time zone
+		if (typeof Intl === 'object' && isFunction(Intl.DateTimeFormat)) {
+			var zone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+			if (zone && (zone.indexOf("/") > -1 || zone === 'UTC')) {
+				return zone;
+			}
+		}
+
 		var offsets = userOffsets(),
 			offsetsLength = offsets.length,
 			guesses = guessesForUserOffsets(offsets),


### PR DESCRIPTION
Since the ECMA-402 Internationalization API provides a mechanism to get the current time zone, we should use it when available and fully implemented.

Note that we also need to guard against a few bad android implementations that return non-IANA time zone IDs.  (jstzdetect ran into this)

This will address #290 