### PR TITLE
Change dependency on moment to a peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
 		"url": "https://github.com/moment/moment-timezone/issues"
 	},
 	"license" : "MIT",
-	"dependencies" : {
+	"peerDependencies" : {
 		"moment" : ">= 2.6.0"
 	},
 	"devDependencies" : {
@@ -34,7 +34,8 @@
 		"grunt-contrib-clean"    : "0.6.0",
 		"grunt-contrib-nodeunit" : "0.4.1",
 		"grunt-contrib-jshint"   : "0.11.2",
-		"grunt-contrib-uglify"   : "0.9.1"
+		"grunt-contrib-uglify"   : "0.9.1",
+		"moment" : ">= 2.6.0"
 	},
 	"jspm" : {
 		"main": "builds/moment-timezone-with-data",


### PR DESCRIPTION
@timrwood changing moment into a peerDependency means that the user of moment-timezone can specify which exact version of moment they want to use with moment-timezone, instead of installing two versions of moment at the same time