### PR TITLE
Ensure timezone abbreviations are in alphabets

### DIFF
--- a/moment-timezone.js
+++ b/moment-timezone.js
@@ -202,13 +202,14 @@
 
 	function OffsetAt(at) {
 		var timeString = at.toTimeString();
-		var abbr = timeString.match(/\(.+\)/);
+		var abbr = timeString.match(/\([a-z ]+\)/i);
 		if (abbr && abbr[0]) {
 			// 17:56:31 GMT-0600 (CST)
 			// 17:56:31 GMT-0600 (Central Standard Time)
 			abbr = abbr[0].match(/[A-Z]/g).join('');
 		} else {
 			// 17:56:31 CST
+			// 17:56:31 GMT+0800 (台北標準時間)
 			abbr = timeString.match(/[A-Z]{3,5}/g)[0];
 		}
 


### PR DESCRIPTION
The timezone abbreviation(Taiwan or China) on "Chrome / Windows 7" isn't an alphabet string.

It returns something like this:

```
(new Date()).toTimeString()
=> '17:56:31 GMT+0800 (台北標準時間)'
```

I've changed the regular expression in `OffsetAt` to let `abbr` property from non-alphabet timezones   as `undefined`