### PR TITLE
Continuing: use Intl API for guessing when available

### DIFF
--- a/moment-timezone.js
+++ b/moment-timezone.js
@@ -321,15 +321,15 @@
 	function rebuildGuess () {
 
 		// use Intl API when available and returning valid time zone
-		if (typeof Intl === 'object' && isFunction(Intl.DateTimeFormat)) {
-			var zone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-			if (typeof zone === 'string') {
-				if (names[normalizeName(zone)]) {
-					return zone;
-				} else {
-					logError("Moment Timezone found " + zone + " from the Intl api, but did not have that data loaded.");
-				}
+		try {
+			var intlName = Intl.DateTimeFormat().resolvedOptions().timeZone;
+			var name = names[normalizeName(intlName)];
+			if (name) {
+				return name;
 			}
+			logError("Moment Timezone found " + intlName + " from the Intl api, but did not have that data loaded.");
+		} catch (e) {
+			// Intl unavailable, fall back to manual guessing.
 		}
 
 		var offsets = userOffsets(),

--- a/moment-timezone.js
+++ b/moment-timezone.js
@@ -323,8 +323,12 @@
 		// use Intl API when available and returning valid time zone
 		if (typeof Intl === 'object' && isFunction(Intl.DateTimeFormat)) {
 			var zone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-			if (zone && (zone.indexOf("/") > -1 || zone === 'UTC')) {
-				return zone;
+			if (typeof zone === 'string') {
+				if (names[normalizeName(zone)]) {
+					return zone;
+				} else {
+					logError("Moment Timezone found " + zone + " from the Intl api, but did not have that data loaded.");
+				}
 			}
 		}
 

--- a/moment-timezone.js
+++ b/moment-timezone.js
@@ -358,10 +358,6 @@
 		return cachedGuess;
 	}
 
-	function isFunction(input) {
-		return input instanceof Function || Object.prototype.toString.call(input) === '[object Function]';
-	}
-
 	/************************************
 		Global Methods
 	************************************/

--- a/tests/helpers/helpers.js
+++ b/tests/helpers/helpers.js
@@ -3,7 +3,8 @@
 var moment = require('../../index');
 var getTimezoneOffset = Date.prototype.getTimezoneOffset;
 var toTimeString = Date.prototype.toTimeString;
-var oldIntl = global.Intl;
+var parent = (typeof window !== 'undefined' && window) || (typeof global !== 'undefined' && global);
+var oldIntl = parent.Intl;
 
 function getUTCOffset (m) {
 	if (m.utcOffset !== undefined) {
@@ -48,7 +49,7 @@ function mockToTimeString(name, format) {
 }
 
 function testGuess(test, name, mostPopulatedFor) {
-	global.Intl = undefined;
+	parent.Intl = undefined;
 
 	if (mostPopulatedFor.offset) {
 		mockTimezoneOffset(name);
@@ -64,7 +65,7 @@ function testGuess(test, name, mostPopulatedFor) {
 
 	Date.prototype.getTimezoneOffset = getTimezoneOffset;
 	Date.prototype.toTimeString = toTimeString;
-	global.Intl = oldIntl;
+	parent.Intl = oldIntl;
 	test.done();
 }
 

--- a/tests/helpers/helpers.js
+++ b/tests/helpers/helpers.js
@@ -3,6 +3,7 @@
 var moment = require('../../index');
 var getTimezoneOffset = Date.prototype.getTimezoneOffset;
 var toTimeString = Date.prototype.toTimeString;
+var oldIntl = global.Intl;
 
 function getUTCOffset (m) {
 	if (m.utcOffset !== undefined) {
@@ -47,6 +48,8 @@ function mockToTimeString(name, format) {
 }
 
 function testGuess(test, name, mostPopulatedFor) {
+	global.Intl = undefined;
+
 	if (mostPopulatedFor.offset) {
 		mockTimezoneOffset(name);
 		mockToTimeString(name);
@@ -61,6 +64,7 @@ function testGuess(test, name, mostPopulatedFor) {
 
 	Date.prototype.getTimezoneOffset = getTimezoneOffset;
 	Date.prototype.toTimeString = toTimeString;
+	global.Intl = oldIntl;
 	test.done();
 }
 

--- a/tests/moment-timezone/guess.js
+++ b/tests/moment-timezone/guess.js
@@ -4,7 +4,8 @@ var tz = require("../../").tz;
 
 var getTimezoneOffset = Date.prototype.getTimezoneOffset;
 var toTimeString = Date.prototype.toTimeString;
-var oldIntl = global.Intl;
+var parent = (typeof window !== 'undefined' && window) || (typeof global !== 'undefined' && global);
+var oldIntl = parent.Intl;
 
 function mockTimezoneOffset (zone, format) {
 	Date.prototype.getTimezoneOffset = function () {
@@ -16,7 +17,7 @@ function mockTimezoneOffset (zone, format) {
 }
 
 function mockIntlTimeZone (name) {
-	global.Intl = {
+	parent.Intl = {
 		DateTimeFormat: function () {
 			return {
 				resolvedOptions: function () {
@@ -31,14 +32,14 @@ function mockIntlTimeZone (name) {
 
 exports.guess = {
 	setUp : function (done) {
-		global.Intl = undefined;
+		parent.Intl = undefined;
 		done();
 	},
 
 	tearDown : function (done) {
 		Date.prototype.getTimezoneOffset = getTimezoneOffset;
 		Date.prototype.toTimeString = toTimeString;
-		global.Intl = oldIntl;
+		parent.Intl = oldIntl;
 		done();
 	},
 


### PR DESCRIPTION
Continuing work on #291.

> Since the ECMA-402 Internationalization API provides a mechanism to get the current time zone, we should use it when available and fully implemented.

All of the dot accessors in `Intl.DateTimeFormat().resolvedOptions().timeZone` were worrying me, especially with a relatively new browser api, so I switched from the `typeof` and `isFunction` checks to a `try/catch`.

I also added a check that the output from `Intl.DateTimeFormat().resolvedOptions().timeZone` was actually loaded, logging an error if it wasn't.

