### PR TITLE
Checking for undefined Intl.DateTimeFormat().resolvedOptions().timeZone

### DIFF
--- a/moment-timezone.js
+++ b/moment-timezone.js
@@ -325,11 +325,13 @@
 		// use Intl API when available and returning valid time zone
 		try {
 			var intlName = Intl.DateTimeFormat().resolvedOptions().timeZone;
-			var name = names[normalizeName(intlName)];
-			if (name) {
-				return name;
+			if (intlName){
+				var name = names[normalizeName(intlName)];
+				if (name) {
+					return name;
+				}
+				logError("Moment Timezone found " + intlName + " from the Intl api, but did not have that data loaded.");
 			}
-			logError("Moment Timezone found " + intlName + " from the Intl api, but did not have that data loaded.");
 		} catch (e) {
 			// Intl unavailable, fall back to manual guessing.
 		}

--- a/tests/moment-timezone/guess.js
+++ b/tests/moment-timezone/guess.js
@@ -89,6 +89,22 @@ exports.guess = {
 		test.done();
 	},
 
+	"When Intl is available, but timeZone is undefined, should return a guess without logging an error" : function (test) {
+		var oldError = console.error;
+		var errors = '';
+		console.error = function (message) {
+			errors += message;
+		};
+		
+		mockIntlTimeZone(undefined);
+		mockTimezoneOffset(tz.zone('Europe/London'));
+		test.equal(tz.guess(true), 'Europe/London');
+		test.equal(errors, '');
+
+		console.error = oldError;
+		test.done();
+	},
+
 	"ensure each zone is represented" : function (test) {
 		var names = tz.names();
 		var zone, i;


### PR DESCRIPTION
I found that Intl.DateTimeFormat().resolvedOptions().timeZone returned undefined in FireFox 45.0.1. I'm not sure if my environment is weird or what. This pull request checks for that case and doesn't print out an error, since it doesn't make sense to report the error "Moment Timezone found undefined from the Intl api, but did not have that data loaded."