### PR TITLE
Fix version number for latest tzdata

### DIFF
--- a/tasks/data-dedupe.js
+++ b/tasks/data-dedupe.js
@@ -26,12 +26,12 @@ function dedupe(zone) {
 }
 
 function findVersion (source) {
-	var matches = source.match(/\nVERSION=\s+(\d{4}[a-z])/);
+	var matches = source.match(/\nRelease (\d{4}[a-z]) /);
 
 	if (matches && matches[1]) {
 		return matches[1];
 	}
-	throw new Error("Could not find version from temp/download/latest/Makefile. It should look something like this.\n\nVERSION= 2014e");
+	throw new Error("Could not find version from temp/download/latest/NEWS.");
 }
 
 module.exports = function (grunt) {
@@ -46,7 +46,7 @@ module.exports = function (grunt) {
 			};
 
 		if (version === 'latest') {
-			output.version = findVersion(grunt.file.read('temp/download/latest/Makefile'));
+			output.version = findVersion(grunt.file.read('temp/download/latest/NEWS'));
 		}
 
 		grunt.file.mkdir('data/unpacked');


### PR DESCRIPTION
Due to changes in the tzdata, we can no longer grab the version number from the `Makefile`.  Until the tz list resolves this, the best we can do is take the first release mentioned from the `NEWS` file.

This is the same approach [being taken by other library maintainers](http://mm.icann.org/pipermail/tz/2016-October/024279.html).