### PR TITLE
add typescript definitions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - 0.10
+  - 5
 before_script:
   - npm install -g grunt-cli
 sudo: false

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -34,6 +34,12 @@ module.exports = function(grunt) {
 			all: 'moment-timezone.js'
 		},
 
+		exec: {
+			'typescript-test': {
+				command: 'node_modules/.bin/ntsc --project typing-tests'
+			}
+		},
+
 		clean: {
 			data: ['temp']
 		}
@@ -45,10 +51,14 @@ module.exports = function(grunt) {
 	grunt.loadNpmTasks('grunt-contrib-jshint');
 	grunt.loadNpmTasks('grunt-contrib-uglify');
 	grunt.loadNpmTasks('grunt-contrib-clean');
+	grunt.loadNpmTasks('grunt-exec');
+
+	grunt.registerTask('test:typescript', ['exec:typescript-test']);
+	grunt.registerTask('test', ['test:typescript']);
 
 	grunt.registerTask('release', ['jshint', 'data', 'nodeunit', 'build', 'uglify']);
 
 	grunt.registerTask('releaseNoData', ['jshint', 'nodeunit', 'build', 'uglify']);
 
-	grunt.registerTask('default', ['jshint', 'nodeunit']);
+	grunt.registerTask('default', ['jshint', 'nodeunit', 'test']);
 };

--- a/moment-timezone.d.ts
+++ b/moment-timezone.d.ts
@@ -1,0 +1,68 @@
+// Type definitions for moment-timezone.js 0.2
+// Project: http://momentjs.com/timezone/
+// Definitions by: Michel Salib <https://github.com/michelsalib>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../moment/moment.d.ts" />
+
+declare namespace moment {
+  interface MomentBuiltinFormat {
+    __momentBuiltinFormatBrand: any;
+  }
+
+  type MomentFormatSpecification = string | MomentBuiltinFormat | (string | MomentBuiltinFormat)[];
+
+    interface Moment {
+        tz(): string;
+        tz(timezone: string): Moment;
+        zoneAbbr(): string;
+        zoneName(): string;
+    }
+
+    interface MomentZone {
+        name: string;
+        abbrs: string[];
+        untils: number[];
+        offsets: number[];
+
+        abbr(timestamp: number): string;
+        offset(timestamp: number): number;
+        parse(timestamp: number): number;
+    }
+
+    interface MomentTimezone {
+        (): moment.Moment;
+        (timezone: string): moment.Moment;
+        (date: number, timezone: string): moment.Moment;
+        (date: number[], timezone: string): moment.Moment;
+        (date: string, timezone: string): moment.Moment;
+        (date: string, format: moment.MomentFormatSpecification, timezone: string): moment.Moment;
+        (date: string, format: moment.MomentFormatSpecification, strict: boolean, timezone: string): moment.Moment;
+        (date: string, format: moment.MomentFormatSpecification, language: string, timezone: string): moment.Moment;
+        (date: string, format: moment.MomentFormatSpecification, language: string, strict: boolean, timezone: string): moment.Moment;
+        (date: Date, timezone: string): moment.Moment;
+        (date: moment.Moment, timezone: string): moment.Moment;
+        (date: any, timezone: string): moment.Moment;
+
+        zone(timezone: string): MomentZone;
+
+        add(packedZoneString: string): void;
+        add(packedZoneString: string[]): void;
+
+        link(packedLinkString: string): void;
+        link(packedLinkString: string[]): void;
+
+        load(data: {
+            version: string;
+            links: string[];
+            zones: string[];
+        }): void;
+
+        names(): string[];
+        guess(): string;
+
+        setDefault(timezone: string): void;
+    }
+
+    const tz: MomentTimezone;
+}

--- a/moment-timezone.d.ts
+++ b/moment-timezone.d.ts
@@ -6,11 +6,11 @@
 /// <reference path="../moment/moment.d.ts" />
 
 declare namespace moment {
-  interface MomentBuiltinFormat {
-    __momentBuiltinFormatBrand: any;
-  }
+    interface MomentBuiltinFormat {
+        __momentBuiltinFormatBrand: any;
+    }
 
-  type MomentFormatSpecification = string | MomentBuiltinFormat | (string | MomentBuiltinFormat)[];
+    type MomentFormatSpecification = string | MomentBuiltinFormat | (string | MomentBuiltinFormat)[];
 
     interface Moment {
         tz(): string;

--- a/moment-timezone.d.ts
+++ b/moment-timezone.d.ts
@@ -3,14 +3,15 @@
 // Definitions by: Michel Salib <https://github.com/michelsalib>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/// <reference path="../moment/moment.d.ts" />
+import * as moment from 'moment';
 
-declare namespace moment {
+// require("moment-timezone") === require("moment")
+export = moment;
+
+declare module "moment" {
     interface MomentBuiltinFormat {
         __momentBuiltinFormatBrand: any;
     }
-
-    type MomentFormatSpecification = string | MomentBuiltinFormat | (string | MomentBuiltinFormat)[];
 
     interface Moment {
         tz(): string;

--- a/package.json
+++ b/package.json
@@ -34,7 +34,10 @@
 		"grunt-contrib-clean"    : "0.6.0",
 		"grunt-contrib-nodeunit" : "0.4.1",
 		"grunt-contrib-jshint"   : "0.11.2",
-		"grunt-contrib-uglify"   : "0.9.1"
+		"grunt-contrib-uglify"   : "0.9.1",
+		"grunt-exec"             : "^2.0.0",
+		"ntypescript"            : "^1.201609302242.1"
+
 	},
 	"jspm" : {
 		"main": "builds/moment-timezone-with-data",

--- a/typing-tests/moment-timezone-tests.ts
+++ b/typing-tests/moment-timezone-tests.ts
@@ -1,0 +1,85 @@
+/// <reference path="../moment-timezone.d.ts" />
+import moment = require('moment-timezone');
+
+var june = moment("2014-06-01T12:00:00Z");
+june.tz('America/Los_Angeles').format('ha z');
+
+var a = moment.tz("2013-11-18 11:55", "America/Toronto");
+var b = moment.tz("May 12th 2014 8PM", "MMM Do YYYY hA", "America/Toronto");
+var c = moment.tz(1403454068850, "America/Toronto");
+var d = moment.tz("May 12th 2014 8PM", "MMM Do YYYY hA", true, "America/Toronto");
+
+a.tz();
+
+var num = 1367337600000,
+    arr = [2013, 5, 1],
+    str = "2013-12-01",
+    date = new Date(2013, 4, 1),
+    mo = moment([2013, 4, 1]),
+    obj = { year : 2013, month : 5, day : 1 },
+    format = "YYYY-MM-DD",
+    formats = ["YYYY-MM-DD", "YYYY/MM/DD"],
+    formatsIncludingSpecial = ["YYYY-MM-DD", moment.ISO_8601],
+    language = "en";
+
+moment.tz();
+moment.tz("America/Los_Angeles");
+
+moment.tz(num, "America/Los_Angeles");
+moment.tz(arr, "America/Los_Angeles");
+moment.tz(str, "America/Los_Angeles");
+moment.tz(str, format, "America/Los_Angeles");
+moment.tz(str, format, true, "America/Los_Angeles");
+moment.tz(str, format, language, "America/Los_Angeles");
+moment.tz(str, format, language, true, "America/Los_Angeles");
+moment.tz(str, formats, "America/Los_Angeles");
+moment.tz(str, formats, true, "America/Los_Angeles");
+moment.tz(str, formats, language, "America/Los_Angeles");
+moment.tz(str, formats, language, true, "America/Los_Angeles");
+moment.tz(str, moment.ISO_8601, "America/Los_Angeles");
+moment.tz(str, moment.ISO_8601, true, "America/Los_Angeles");
+moment.tz(str, moment.ISO_8601, language, "America/Los_Angeles");
+moment.tz(str, moment.ISO_8601, language, true, "America/Los_Angeles");
+moment.tz(str, formatsIncludingSpecial, "America/Los_Angeles");
+moment.tz(str, formatsIncludingSpecial, true, "America/Los_Angeles");
+moment.tz(str, formatsIncludingSpecial, language, "America/Los_Angeles");
+moment.tz(str, formatsIncludingSpecial, language, true, "America/Los_Angeles");
+
+moment.tz(date, "America/Los_Angeles");
+moment.tz(mo, "America/Los_Angeles");
+moment.tz(obj, "America/Los_Angeles");
+
+moment.tz.zone('America/Los_Angeles').abbr(1403465838805);
+moment.tz.zone('America/Los_Angeles').offset(1403465838805);
+
+var zone = moment.tz.zone('America/New_York');
+zone.parse(Date.UTC(2012, 2, 19, 8, 30)); // 240
+
+moment.tz.add('America/Los_Angeles|PST PDT|80 70|0101|1Lzm0 1zb0 Op0');
+moment.tz.add([
+    'America/Los_Angeles|PST PDT|80 70|0101|1Lzm0 1zb0 Op0',
+    'America/New_York|EST EDT|50 40|0101|1Lz50 1zb0 Op0'
+]);
+
+moment.tz.link('America/Los_Angeles|US/Pacific');
+moment.tz.link([
+    'America/Los_Angeles|US/Pacific',
+    'America/New_York|US/Eastern'
+]);
+
+moment.tz.load({
+    zones : [],
+    links : [],
+    version : '2014e'
+});
+
+moment.tz.names();
+
+moment.tz.setDefault('America/Los_Angeles');
+
+moment.tz.guess();
+
+var zoneAbbr: string = moment.tz('America/Los_Angeles').zoneAbbr();
+
+var zoneName: string = moment.tz('America/Los_Angeles').zoneName();
+

--- a/typing-tests/tsconfig.json
+++ b/typing-tests/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compileOnSave": false,
+  "compilerOptions": {
+    "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": false,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+  },
+  "files": [
+    "../moment-timezone.d.ts",
+    "./moment-timezone-tests.ts"
+  ]
+}


### PR DESCRIPTION
Reference: Add typescript definitions #341
Reference: Module 'moment' has no exported member 'MomentFormatSpecification' #343 

I couldn't come up with a solution to 343 other than copying lines 9-13 into the typescript file for moment-timezone.

Supports: https://github.com/grafana/clock-panel/pull/19