### PR TITLE
Add es module default export interop

### DIFF
--- a/moment-timezone.js
+++ b/moment-timezone.js
@@ -18,6 +18,8 @@
 }(this, function (moment) {
 	"use strict";
 
+	moment = moment && moment.hasOwnProperty('default') ? moment['default'] : moment;
+
 	// Do not load moment-timezone a second time.
 	// if (moment.tz !== undefined) {
 	// 	logError('Moment Timezone ' + moment.tz.version + ' was already loaded ' + (moment.tz.dataVersion ? 'with data from ' : 'without any data') + moment.tz.dataVersion);


### PR DESCRIPTION
Closes #540 and #449. This replaces #541 and #514.

Moment, when imported as an ES6 module, has a default export. This isn't handled by `moment-timezone`. The addition in this PR is the same output you would receive from a UMD build from [rollup](https://rollupjs.org/) that will handle the case that is causing the reported default import issues.