### PR TITLE
Ensure Intl response is valid

### DIFF
--- a/moment-timezone.js
+++ b/moment-timezone.js
@@ -330,7 +330,7 @@
 		// use Intl API when available and returning valid time zone
 		try {
 			var intlName = Intl.DateTimeFormat().resolvedOptions().timeZone;
-			if (intlName){
+			if (intlName && intlName.length > 3) {
 				var name = names[normalizeName(intlName)];
 				if (name) {
 					return name;


### PR DESCRIPTION
Fixes #423 by ignoring any results from the Intl API that aren't at least three characters long.