### PR TITLE
Exclude vulnerable versions of moment

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 	},
 	"license": "MIT",
 	"dependencies": {
-		"moment": ">= 2.9.0"
+		"moment": ">= 2.19.3"
 	},
 	"devDependencies": {
 		"grunt": "1.0.2",


### PR DESCRIPTION
There is a vulnerability in `moment` prior to the 2.19.3
http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-18214