### PR TITLE
Move moment to peerDependencies

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,10 @@
 ### `0.5.14` _2017-10-30_
-* Updated data to IANA TZDB `2017c`. [#552](https://github.com/moment/moment-timezone/pull/552)
 * Ensure Intl response is valid when guessing time zone. [#553](https://github.com/moment/moment-timezone/pull/553)
+* Updated data to IANA TZDB `2017c`. [#552](https://github.com/moment/moment-timezone/pull/552)
+* Convert to tz keeping wall time [#505](https://github.com/moment/moment-timezone/pull/505)
 * Make all time zones available for guessing. [#483](https://github.com/moment/moment-timezone/pull/483)
+* zone.offset has been deprecated in favor of zone.utcOffset [#398](https://github.com/moment/moment-timezone/pull/398)
+* Check for timestamp formats when parsing [#348](https://github.com/moment/moment-timezone/pull/348)
 
 ### `0.5.13` _2017-04-04_
 * Bumped version to address Bower cache issues with last release.  [#474](https://github.com/moment/moment-timezone/issues/474)

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
 		"url": "https://github.com/moment/moment-timezone/issues"
 	},
 	"license": "MIT",
-	"dependencies": {
+	"peerDependencies": {
 		"moment": ">= 2.9.0"
 	},
 	"devDependencies": {
@@ -34,7 +34,8 @@
 		"grunt-contrib-clean": "^1.1.0",
 		"grunt-contrib-jshint": "^1.1.0",
 		"grunt-contrib-nodeunit": "^1.0.0",
-		"grunt-contrib-uglify": "^3.1.0"
+		"grunt-contrib-uglify": "^3.1.0",
+		"moment": ">= 2.9.0"
 	},
 	"jspm": {
 		"main": "builds/moment-timezone-with-data",


### PR DESCRIPTION
It avoids having 2 instances of moment loaded in the project.

Fixes https://github.com/moment/moment-timezone/issues/132
Fixes https://github.com/moment/moment-timezone/issues/449