### PR TITLE
Change moment to be a peerDependency and a devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,10 +26,11 @@
 		"url": "https://github.com/moment/moment-timezone/issues"
 	},
 	"license": "MIT",
-	"dependencies": {
+	"peerDependencies": {
 		"moment": ">= 2.9.0"
 	},
 	"devDependencies": {
+		"moment": ">= 2.9.0",
 		"grunt": "^1.0.1",
 		"grunt-contrib-clean": "^1.1.0",
 		"grunt-contrib-jshint": "^1.1.0",


### PR DESCRIPTION
Currently, when using moment-timezone, moment is installed as a dependency.
This means if I have moment installed as a dependency in general, it won't be reused. Instead, moment-timezone uses its own version of moment.

This is leading to issues with a locale magically not being set or similar, as the "wrong" moment dependency is being used.

With this pull-request, moment is defined as a peer-dependency, which means it will be reused from an existing dependency. In a dev setup, we want to install moment in any case, this is why I added it to the devDependencies aswell.