### PR TITLE
Fix for use when momentJS is nested.

### DIFF
--- a/moment-timezone.js
+++ b/moment-timezone.js
@@ -15,7 +15,7 @@
 	} else {
 		factory(root.moment);                        // Browser
 	}
-}(this, function (moment) {
+}(this, function (_moment) {
 	"use strict";
 
 	// Do not load moment-timezone a second time.
@@ -23,6 +23,10 @@
 	// 	logError('Moment Timezone ' + moment.tz.version + ' was already loaded ' + (moment.tz.dataVersion ? 'with data from ' : 'without any data') + moment.tz.dataVersion);
 	// 	return moment;
 	// }
+	var moment = _moment;
+	if (_moment && !_moment.version && _moment.default) {
+		moment = _moment.default;
+	}
 
 	var VERSION = "0.5.21",
 		zones = {},


### PR DESCRIPTION
During the webpack process, momentJS is nested inside {default: ... }. A simple test asserts if moment is not in fact at the highest level, but nested one level deeper.

The if statement asserts that .version is missing while .default exists. A variable was made to avoid reassignment to a parameter (which is considered bad practice).

All tests pass. Works in my production software with this patch.

PS: This seems to be a problem others have as well: https://github.com/moment/moment-timezone/issues/449