### PR TITLE
fix: stabilize Array.sort

### DIFF
--- a/moment-timezone.js
+++ b/moment-timezone.js
@@ -292,7 +292,10 @@
 		if (a.abbrScore !== b.abbrScore) {
 			return a.abbrScore - b.abbrScore;
 		}
-		return b.zone.population - a.zone.population;
+		if (a.zone.population !== b.zone.population) {
+			return b.zone.population - a.zone.population;
+		}
+		return b.zone.name.localeCompare(a.zone.name);
 	}
 
 	function addToGuesses (name, offsets) {


### PR DESCRIPTION
This PR stabilizes the sorting as it was instable before NodeJS 11 (V8 v7.0) and in NodeJS it was stabilized as the sorting algorithm was changed to TimSort with a pre-peocessing and a post-processing phase.

References:
https://github.com/nodejs/node/issues/24294
https://v8.dev/blog/array-sort

Probably we should change the added logic to order by name because `America/Caracas` and `America/Santo_Domingo` have the same `abbrScore`, `offsetScore` and `zone.population` but `C` comes before `S` in the alphabet and so it should be probably first (many breaking tests due to stable sorting now).

```
ZoneScore {
    zone: {
      name: 'America/Caracas',
      abbrs: [Array],
      untils: [Array],
      offsets: [Array],
      population: 2900000
    },
    offsetScore: 0,
    abbrScore: 9
  },
  ZoneScore {
    zone: {
      name: 'America/Santo_Domingo',
      abbrs: [Array],
      untils: [Array],
      offsets: [Array],
      population: 2900000
    },
    offsetScore: 0,
    abbrScore: 9
  },
```