### PR TITLE
ci: add Node.js 10, remove Node.js 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: node_js
 node_js:
   - "node"
+  - "10"
   - "8"
   - "6"
-  - "4"
 install:
   - npm install
   - npm install -g grunt-cli


### PR DESCRIPTION
NodeJS 10 is the current LTS and NodeJS 4 reached EOL last year.
NodeJS 6 reached its EOL this years and there are still many users who use NodeJS 6.

https://nodejs.org/en/about/releases/
https://github.com/nodejs/Release/blob/master/README.md

https://nodesource.com/node-by-numbers
https://nodejs.org/metrics/

![NodeJS version usage chart](https://nodejs.org/metrics/summaries/version.png)