### PR TITLE
Fixed changelog to represent proper release versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: node_js
 node_js:
   - "node"
   - "8"
-  - "6"
-  - "4"
 install:
   - npm install
   - npm install -g grunt-cli

--- a/changelog.md
+++ b/changelog.md
@@ -1,11 +1,11 @@
-### `0.5.29` _2020-02-21_
+### `0.5.28` _2020-02-21_
 Merged pull request #410 from @adgrace:
 * Added a method `moment.tz.zonesForCountry(country_code)` which returns all timezones for the country
 * Added a method `moment.tz(timezone_id).countries()` to get countries for some time zone
 * Added a method `moment.tz.countries()` to get all country codes
 * And as you know `moment.tz.zones()` already exists
 
-### `0.5.28` _2019-10-14_
+### `0.5.27` _2019-10-14_
 * Updated data to IANA TZDB `2019c`
 
 ### `0.5.26` _2019-06-06_


### PR DESCRIPTION
The latest 2 versions stated in the current changelog were shifted, resulting in misleading versions (0.5.29 doesn't exist yet).