### PR TITLE
Correcting latest.json > countries > HR (Croatia)

### DIFF
--- a/data/packed/latest.json
+++ b/data/packed/latest.json
@@ -694,7 +694,7 @@
 		"GY|America/Guyana",
 		"HK|Asia/Hong_Kong",
 		"HN|America/Tegucigalpa",
-		"HR|Europe/Belgrade Europe/Zagreb",
+		"HR|Europe/Zagreb",
 		"HT|America/Port-au-Prince",
 		"HU|Europe/Budapest",
 		"ID|Asia/Jakarta Asia/Pontianak Asia/Makassar Asia/Jayapura",


### PR DESCRIPTION
Some facts first: 
  - Croatia and Serbia are sovereign nations of Europe
  - Zagreb is the capital of Croatia (HR, local name: Hrvatska)
  - Belgrade is the capital of Serbia (RS, as in "Republic of Serbia")

In the `latest.json > countries > HR`:
Croatia `HR`  is incorrectly set to `Europe/Belgrade Europe/Zagreb`.
Serbia `RS` is correctly set to `Europe/Belgrade`, so no need to make any changes there.

Thanks