### PR TITLE
fixing build on non mac systems like linux

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,8 @@
+### Moment-timezone version which you use:
+
+Version:
+
+_Note: many issues are resolved if you just upgrade to the latest version_
+
+### Issue description:
+

--- a/tasks/data-zdump.js
+++ b/tasks/data-zdump.js
@@ -37,9 +37,16 @@ module.exports = function (grunt) {
 			exec('zdump -v ' + src, { maxBuffer: 20*1024*1024 }, function (err, stdout) {
 				if (err) { throw err; }
 
+				let output = normalizePaths(stdout);
+				let lines = output.split('\n');
+				let validOutput = lines.some(function (line) {
+					var parts = line.split(/\s+/);
+					return parts.length > 13;
+				});
+
 				grunt.file.mkdir(path.dirname(dest));
 
-				if (stdout.length === 0) {
+				if (!validOutput) {
 					// on some systems, when there are no transitions then we have
 					// to get creative to learn the offset and abbreviation
 					exec('zdump UTC ' + src, { maxBuffer: 20*1024*1024 }, function (_err, _stdout) {


### PR DESCRIPTION
When TZ data is updated on linux using grunt data command, zdump output in case of no transition is not to the linking of grunt data-collect task. This fix ensures that usable zdump files get generated even in such cases