### PR TITLE
Don't try to guess timezone for UTC

### DIFF
--- a/moment-timezone.js
+++ b/moment-timezone.js
@@ -359,7 +359,7 @@
 		// use Intl API when available and returning valid time zone
 		try {
 			var intlName = Intl.DateTimeFormat().resolvedOptions().timeZone;
-			if (intlName && intlName.length > 3) {
+			if (intlName && intlName.length) {
 				var name = names[normalizeName(intlName)];
 				if (name) {
 					return name;


### PR DESCRIPTION
In the IANA database, there are two main kinds of time zones.  First, there are the timezones, such as America/Los_Angeles, that reflect a physical location.  When a user specifies one of this type of time zone, that is usually because they are or were physically present in that time zone, or something relevant to them is located in that physical time zone.

The other kind, like UTC and the GMT offset time zones, represents some arbitrary (possibly zero) offset from UTC or another time reference. These usually do not indicate the user is physically present, and are used when the user explicitly prefers a fixed offset.  This is common for server infrastructure which must be maintained across time zones.

The code which checks for time zones, however, looks to see if the user's specified time zone is greater than three characters.  If it is not, it attempts to guess the time zone by rewriting the offset into some time zone in that offset.  This unfortunately rewrites "UTC" into the first alphabetical entry which represents it, which is "Africa/Abidjan".

As mentioned above, while it is the case that Abidjan (and, for that matter, all of Côte d'Ivoire) are in the same offset as UTC, the two time zones provide semantically different meanings.  To avoid this problem, let's remove the restriction on length to allow users to specify a value such as "UTC" or "GMT" if that's the best option, and simply check that the length of the name is nonzero instead.

Fixes #559