### PR TITLE
Add deprecation warning to 2012-2022 pre-built files

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -18,7 +18,7 @@ module.exports = function(grunt) {
 		build : {
 			'moment-timezone-with-data'               : true,
 			'moment-timezone-with-data-1970-2030'     : [1970, 2030],
-			'moment-timezone-with-data-2012-2022'     : [2012, 2022],
+			'moment-timezone-with-data-2012-2022'     : [2012, 2022, 'warn'],
 			'moment-timezone-with-data-10-year-range' : [currentYear - 5, currentYear + 5]
 		},
 

--- a/tasks/builds.js
+++ b/tasks/builds.js
@@ -3,6 +3,19 @@
 var tz = require('../moment-timezone-utils').tz,
     groupLeaders = require('./group-leaders.json');
 
+// A cut-down version of `deprecate()` from core moment.js
+function staleDataWarning() {
+	if (moment.suppressDeprecationWarnings === false &&
+			(typeof console !==  'undefined') && console.warn) {
+		console.warn(
+			'Deprecation warning: ' +
+			'Moment Timezone has been loaded from a file containing data from 2012 to 2022 only. ' +
+			'This file is out of date and may be removed in a future release. ' +
+			'Dates and times for the current year might be incorrect.'
+		);
+	}
+}
+
 module.exports = function (grunt) {
 	grunt.registerMultiTask('build', 'Build minified versions with data included.', function () {
 		var dest   = 'builds/' + this.target + '.js',
@@ -23,6 +36,11 @@ module.exports = function (grunt) {
 		data = JSON.stringify(data, null, '\t');
 		data = data.split('\n').join('\n\t');
 		data = 'loadData(' + data + ');\n';
+
+		if (this.data && this.data[2] === 'warn') {
+			data += '\n\t' + staleDataWarning.toString().split('\n').join('\n\t')
+				+ '\n\tstaleDataWarning();'
+		}
 
 		source = source.replace('// INJECT DATA', data);
 


### PR DESCRIPTION
It's 2023 now, these files are producing incorrect results for the current year.

Fixes #1035