### PR TITLE
Update 2024a.json

### DIFF
--- a/data/meta/2024a.json
+++ b/data/meta/2024a.json
@@ -341,9 +341,6 @@
 				"America/Whitehorse",
 				"America/Dawson",
 				"America/Vancouver",
-				"America/Panama",
-				"America/Puerto_Rico",
-				"America/Phoenix",
 				"America/Blanc-Sablon",
 				"America/Atikokan",
 				"America/Creston"


### PR DESCRIPTION
Removed Phoenix, Puerto_Rico, Panama which are not located in Canada and do not function as timezones for the country's zone.