### PR TITLE
fix: update offset error with daylight saving time

### DIFF
--- a/moment-timezone.js
+++ b/moment-timezone.js
@@ -652,7 +652,15 @@
 				offset = offset / 60;
 			}
 			if (mom.utcOffset !== undefined) {
+				var _offset = mom._offset;
 				var z = mom._z;
+				if (keepTime && typeof keepTime === 'number' && _offset && -offset > _offset) {
+					var preMom = moment(mom.valueOf() - (-offset - _offset) * 60 * 1000);
+					var preOffset = mom._z.utcOffset(preMom);
+					if (offset !== preOffset) {
+						keepTime = false;
+					}
+				}
 				mom.utcOffset(-offset, keepTime);
 				mom._z = z;
 			} else {

--- a/tests/moment-timezone/manipulate.js
+++ b/tests/moment-timezone/manipulate.js
@@ -16,6 +16,26 @@ exports.manipulate = {
 
 	add : function (t) {
 		t.equal(
+			moment('2024-09-07T00:00:00-04:00').tz('America/Santiago').add(1, 'days').format(),
+			'2024-09-08T01:00:00-03:00',
+			"adding 1 day while crossing a DST boundary should not affect time."
+		);
+		t.equal(
+			moment('2024-09-07T04:00:00-04:00').tz('America/Santiago').add(1, 'days').format(),
+			'2024-09-08T04:00:00-03:00',
+			"adding 1 day while crossing a DST boundary should not affect time."
+		);
+		t.equal(
+			moment('2024-08-08T00:00:00-04:00').tz('America/Santiago').add(1, 'months').format(),
+			'2024-09-08T01:00:00-03:00',
+			"adding 1 day while crossing a DST boundary should not affect time."
+		);
+		t.equal(
+			moment('2024-08-08T04:00:00-04:00').tz('America/Santiago').add(1, 'months').format(),
+			'2024-09-08T04:00:00-03:00',
+			"adding 1 day while crossing a DST boundary should not affect time."
+		);
+		t.equal(
 			moment('2012-10-28 00:00:00+01:00').tz('Europe/London').add(1, 'days').format(),
 			'2012-10-29T00:00:00Z',
 			"adding 1 day while crossing a DST boundary should not affect time (BST -> GMT)."


### PR DESCRIPTION
fix the dst offset calculate error of https://github.com/moment/moment-timezone/issues/1074 and https://github.com/moment/moment-timezone/issues/1017. When update the offset, the hole time (ignore time) of dst should not keepTime in the moment. Here is one way to find the hole time in function updateOffset. Please help to check if any problem.