### PR TITLE
Fix: preserve date when parsing time strings with default timezone

### DIFF
--- a/moment-timezone.js
+++ b/moment-timezone.js
@@ -588,7 +588,7 @@
 		moment.tz namespace
 	************************************/
 	    var originalTzFn = moment.tz;
-  function tz(input) {
+  	function tz(input) {
         var args = Array.prototype.slice.call(arguments, 0, -1),
             name = arguments[arguments.length - 1],
             zone = getZone(name),

--- a/moment-timezone.js
+++ b/moment-timezone.js
@@ -587,21 +587,30 @@
 	/************************************
 		moment.tz namespace
 	************************************/
+	    var originalTzFn = moment.tz;
+  function tz(input) {
+        var args = Array.prototype.slice.call(arguments, 0, -1),
+            name = arguments[arguments.length - 1],
+            zone = getZone(name),
+            out;
 
-	function tz (input) {
-		var args = Array.prototype.slice.call(arguments, 0, -1),
-			name = arguments[arguments.length - 1],
-			out  = moment.utc.apply(null, args),
-			zone;
+        if (typeof input === 'string' && moment.tz.guess && name && originalTzFn) {
+            out = originalTzFn.apply(null, args.concat(name));
+        } else {
+            out = moment.utc.apply(null, args);
+        }
 
-		if (!moment.isMoment(input) && needsOffset(out) && (zone = getZone(name))) {
-			out.add(zone.parse(out), 'minutes');
-		}
+        if (!moment.isMoment(input) && needsOffset(out) && zone) {
+            out.add(zone.parse(out), 'minutes');
+        }
 
-		out.tz(name);
+        out.tz(name);
+        return out;
+    }
 
-		return out;
-	}
+    // 🔁 Patch the exported tz function
+    moment.tz = tz;
+
 
 	tz.version      = VERSION;
 	tz.dataVersion  = '';

--- a/tests/moment-timezone/parse.js
+++ b/tests/moment-timezone/parse.js
@@ -293,6 +293,13 @@ exports.parse = {
 		}
 
 		t.done();
-	}
+	},
+	"bug #874 - parsing time string should respect default timezone": function (test) {
+    moment.tz.setDefault("Asia/Kolkata");
+    var m = moment("T22:00", "THH:mm");
+    test.equal(m.format(), "2025-06-27T22:00:00+05:30", "Should keep same date in default zone");
+    test.done();
+}
+
 
 };

--- a/tests/moment-timezone/parse.js
+++ b/tests/moment-timezone/parse.js
@@ -295,11 +295,11 @@ exports.parse = {
 		t.done();
 	},
 	"bug #874 - parsing time string should respect default timezone": function (test) {
-    moment.tz.setDefault("Asia/Kolkata");
-    var m = moment("T22:00", "THH:mm");
-    test.equal(m.format(), "2025-06-27T22:00:00+05:30", "Should keep same date in default zone");
-    test.done();
-}
+		moment.tz.setDefault("Asia/Kolkata");
+		var m = moment("T22:00", "THH:mm");
+		test.equal(m.format(), "2025-06-27T22:00:00+05:30", "Should keep same date in default zone");
+		test.done();
+	}
 
 
 };


### PR DESCRIPTION
fix: preserve local date when parsing time strings with default timezone

Fixes #874, #867, #807

Previously, parsing time-only strings like "T22:00" in a context with
tz.setDefault("Asia/Kolkata") would incorrectly use the UTC date
and shift the local day. This patch uses the original tz parsing
to ensure the correct local date and time are preserved.

Also includes a test case to confirm behavior.
