### PR TITLE
fix: use correct default day when needed

### DIFF
--- a/moment-timezone.js
+++ b/moment-timezone.js
@@ -588,6 +588,26 @@
 		moment.tz namespace
 	************************************/
 
+	// Re-parse args with moment.now() shifted to the zone's current wall
+	// time, so that any omitted date fields default to "today" in that
+	// zone instead of "today" in UTC. If the input fully specifies its
+	// date fields, this has no effect since the shifted "now" is unused.
+	function todayIn (zone, args) {
+		var realNow  = moment.now(),
+			zoneNow  = realNow - (zone.utcOffset(realNow) * 60000),
+			savedNow = moment.now,
+			out;
+
+		moment.now = function () { return zoneNow; };
+		try {
+			out = moment.utc.apply(null, args);
+		} finally {
+			moment.now = savedNow;
+		}
+
+		return out;
+	}
+
 	function tz (input) {
 		var args = Array.prototype.slice.call(arguments, 0, -1),
 			name = arguments[arguments.length - 1],
@@ -595,6 +615,7 @@
 			zone;
 
 		if (!moment.isMoment(input) && needsOffset(out) && (zone = getZone(name))) {
+			out = todayIn(zone, args);
 			out.add(zone.parse(out), 'minutes');
 		}
 

--- a/tests/moment-timezone/issue-1128.js
+++ b/tests/moment-timezone/issue-1128.js
@@ -1,0 +1,31 @@
+"use strict";
+
+var moment = require("../../index");
+
+exports.issue1128 = {
+	setUp : function (done) {
+		this.realNow = moment.now;
+		done();
+	},
+
+	tearDown : function (done) {
+		moment.now = this.realNow;
+		done();
+	},
+
+	"object with only time fields should use the current date in the target zone, not UTC" : function (t) {
+		// "Now" is 2025-01-02T01:00:00Z: already Jan 2 in UTC, but still
+		// Jan 1 (20:00 EST) in America/New_York.
+		moment.now = function () {
+			return new Date("2025-01-02T01:00:00Z").getTime();
+		};
+
+		var timeObject = { hour : 1, minutes : 23, seconds : 56 };
+		var actual = moment.tz(timeObject, "America/New_York").format();
+
+		t.equal(actual, "2025-01-01T01:23:56-05:00",
+			"Should use the current date in America/New_York (Jan 1), not the current UTC date (Jan 2)");
+
+		t.done();
+	}
+};


### PR DESCRIPTION
Use the correct default day for the current zone instead of the one for UTC. Closes #1128.