### PR TITLE
fix: ensure objects are equal when dst on midnight

### DIFF
--- a/moment-timezone.js
+++ b/moment-timezone.js
@@ -698,11 +698,28 @@
 		};
 	}
 
+	function cloneWrap (old) {
+		return function () {
+			var m = old.apply(this, arguments);
+			if (this._z) {
+				// The Moment constructor re-derives the offset from
+				// scratch via moment.updateOffset, which can disagree
+				// with the source moment when it sits exactly on a DST
+				// transition boundary. Force the clone to match instead.
+				m._d = new Date(this._d.getTime());
+				m._offset = this._offset;
+				m._z = this._z;
+			}
+			return m;
+		};
+	}
+
 	fn.zoneName  = abbrWrap(fn.zoneName);
 	fn.zoneAbbr  = abbrWrap(fn.zoneAbbr);
 	fn.utc       = resetZoneWrap(fn.utc);
 	fn.local     = resetZoneWrap(fn.local);
 	fn.utcOffset = resetZoneWrap2(fn.utcOffset);
+	fn.clone     = cloneWrap(fn.clone);
 
 	moment.tz.setDefault = function(name) {
 		if (major < 2 || (major === 2 && minor < 9)) {

--- a/tests/moment-timezone/clone.js
+++ b/tests/moment-timezone/clone.js
@@ -1,0 +1,23 @@
+"use strict";
+
+var moment = require("../../index");
+
+exports.clone = {
+	"clone preserves the wall time after add() lands on a skipped DST-start hour" : function (t) {
+		// America/Havana turns clocks forward 1 hour at 2020-03-08 00:00,
+		// so that midnight instant does not actually exist. moment.tz
+		// rolls it forward to 2020-03-08 00:00 -04:00, and a clone of
+		// that moment should represent the exact same wall time.
+		var m = moment.tz("2020-03-01", "America/Havana");
+		m.add(1, "week");
+
+		var original = m.format("YYYY-MM-DD HH:mm:ss Z");
+		var cloned = m.clone().format("YYYY-MM-DD HH:mm:ss Z");
+
+		t.equal(original, "2020-03-08 00:00:00 -04:00", "The original moment should land on the DST start");
+		t.equal(cloned, original, "Cloning should not change the displayed wall time");
+		t.equal(m.valueOf(), m.clone().valueOf(), "Cloning should not change the underlying instant");
+
+		t.done();
+	}
+};


### PR DESCRIPTION
This should ensure that the objects have equal values when a moment sits exactly on a Havana-style DST-shift. Closes #826.